### PR TITLE
Fixed overflow bug in binary search.

### DIFF
--- a/kernel/groups.c
+++ b/kernel/groups.c
@@ -142,7 +142,7 @@ int groups_search(const struct group_info *group_info, gid_t grp)
 	left = 0;
 	right = group_info->ngroups;
 	while (left < right) {
-		unsigned int mid = (left+right)/2;
+		unsigned int mid = left + (right - left)/2;
 		if (grp > GROUP_AT(group_info, mid))
 			left = mid + 1;
 		else if (grp < GROUP_AT(group_info, mid))


### PR DESCRIPTION
(left + right)/2 can overflow in cases where left + (right-left)/2 wouldn't.
See, for example left=2 and right=2^32-1.
