### PR TITLE
drm/edid: Fix the HDTV hack yet more.

### DIFF
--- a/drivers/gpu/drm/drm_edid.c
+++ b/drivers/gpu/drm/drm_edid.c
@@ -714,8 +714,8 @@ drm_mode_std(struct drm_connector *connector, struct edid *edid,
 
 	/* HDTV hack, part 1 */
 	if (vrefresh_rate == 60 &&
-	    ((hsize == 1360 && vsize == 765) ||
-	     (hsize == 1368 && vsize == 769))) {
+	    ((hsize >= 1360 && hsize <= 1368) &&
+	     (vsize >= 765 && vsize <= 769))) {
 		hsize = 1366;
 		vsize = 768;
 	}


### PR DESCRIPTION
Checking for just two variants of standard timings for
1366x768 isn't quite correct, let's check for ranges
instead.

Signed-off-by: Andrew Shadura andrew@beldisplaytech.com
