### PR TITLE
[PATCH] ATH6KL: "Fix the byte alignment rule to avoid loss of bytes in a TCP segment"

### DIFF
--- a/drivers/net/wireless/ath/ath6kl/init.c
+++ b/drivers/net/wireless/ath/ath6kl/init.c
@@ -201,8 +201,8 @@ struct sk_buff *ath6kl_buf_alloc(int size)
 	u16 reserved;
 
 	/* Add chacheline space at front and back of buffer */
-	reserved = (2 * L1_CACHE_BYTES) + ATH6KL_DATA_OFFSET +
-		   sizeof(struct htc_packet) + ATH6KL_HTC_ALIGN_BYTES;
+	reserved = roundup((2 * L1_CACHE_BYTES) + ATH6KL_DATA_OFFSET +
+		   sizeof(struct htc_packet) + ATH6KL_HTC_ALIGN_BYTES, 4);
 	skb = dev_alloc_skb(size + reserved);
 
 	if (skb)

--- a/drivers/net/wireless/ath/ath6kl/main.c
+++ b/drivers/net/wireless/ath/ath6kl/main.c
@@ -1327,9 +1327,9 @@ void init_netdev(struct net_device *dev)
 	dev->watchdog_timeo = ATH6KL_TX_TIMEOUT;
 
 	dev->needed_headroom = ETH_HLEN;
-	dev->needed_headroom += sizeof(struct ath6kl_llc_snap_hdr) +
+	dev->needed_headroom += roundup(sizeof(struct ath6kl_llc_snap_hdr) +
 				sizeof(struct wmi_data_hdr) + HTC_HDR_LENGTH
-				+ WMI_MAX_TX_META_SZ + ATH6KL_HTC_ALIGN_BYTES;
+				+ WMI_MAX_TX_META_SZ + ATH6KL_HTC_ALIGN_BYTES, 4);
 
 	dev->hw_features |= NETIF_F_IP_CSUM | NETIF_F_RXCSUM;
 


### PR DESCRIPTION
I found the driver bug which occur loss of some bytes on the TCP/IP stack.

Either first 3 bytes of the first received tcp segment or last one
over MTU size file can be loss due to the byte alignment problem.
Although ATH6KL_HTC_ALIGN_BYTES was defined
for 'extra bytes for htc header alignment'
in the patch "Fix buffer alignment for scatter-gather I/O"(1df94a857),
there exists the bytes loss issue which means that it will be truncated
3 bytes in the transmitted file contents if a file which
has over MTU size is transferred through TCP/IP stack.
It doesn't look like TCP/IP stack bug of 3.5 or the latest version of
kernel but the byte alignment issue.
This patch is to use the roundup() function for the byte alignment
rather than the predefined ATH6KL_HTC_ALIGN_BYTES.

Signed-off-by: Myoungje Kim mjei78@gmail.com
