### PR TITLE
Remove trailing slash from kernel.org link

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-        Linux kernel release 3.x <http://kernel.org/>
+        Linux kernel release 3.x <http://kernel.org>
 
 These are the release notes for Linux version 3.  Read them carefully,
 as they tell you what this is all about, explain how to install the


### PR DESCRIPTION
A trailing slash on a URL connotes a link to a directory; an absence of a trailing slash connotes a link to a page.
