### PR TITLE
fix crypto4xx_core.c compilation error

### DIFF
--- a/drivers/crypto/amcc/crypto4xx_core.c
+++ b/drivers/crypto/amcc/crypto4xx_core.c
@@ -19,6 +19,7 @@
  */
 
 #include <linux/kernel.h>
+#include <linux/module.h>
 #include <linux/interrupt.h>
 #include <linux/spinlock_types.h>
 #include <linux/random.h>


### PR DESCRIPTION
This tiny pull request fixes...
```
...
  CC      drivers/crypto/amcc/crypto4xx_core.o
drivers/crypto/amcc/crypto4xx_core.c:1139:18: error: 'THIS_MODULE' undeclared here (not in a function)
...
```
compilation error.