### PR TITLE
Remove redundant msg.msg_namelen = 0 in drivers/staging/usbip/ubip_common.c

### DIFF
--- a/drivers/staging/usbip/usbip_common.c
+++ b/drivers/staging/usbip/usbip_common.c
@@ -365,7 +365,6 @@ int usbip_recv(struct socket *sock, void *buf, int size)
 		msg.msg_namelen = 0;
 		msg.msg_control = NULL;
 		msg.msg_controllen = 0;
-		msg.msg_namelen    = 0;
 		msg.msg_flags      = MSG_NOSIGNAL;
 
 		result = kernel_recvmsg(sock, &msg, &iov, 1, size, MSG_WAITALL);


### PR DESCRIPTION
Just spotted it from a Google search, thought I'd fix it. One-liner PR.
