### PR TITLE
Add periodictimer to net/MRP to enable retries 

### DIFF
--- a/include/net/mrp.h
+++ b/include/net/mrp.h
@@ -112,6 +112,7 @@ struct mrp_applicant {
 	struct mrp_application	*app;
 	struct net_device	*dev;
 	struct timer_list	join_timer;
+	struct timer_list	periodic_timer;
 
 	spinlock_t		lock;
 	struct sk_buff_head	queue;


### PR DESCRIPTION
Added periodic timer from [802.1Q-2011] to retry if MRP loses messages.  MRP used to lose JoinIn messages and never retry if it sent messages before the interface became ready.

The periodic timer from the 802.1Q spec never turns off.  It fires every second, causing MRP to bounce from state QA to AA and back. You might think that would stop when the registrar responds with an JoinIn, but there's no state in the MRP state table to ignore the periodic timer after getting a reply.  The result is MRP sends a JoinIn message every second.  This may not be desirable, but it's what the spec requires.

[802.1Q-2011]
http://standards.ieee.org/findstds/standard/802.1Q-2011.html
