### PR TITLE
rm redundant empty line

### DIFF
--- a/kernel/time/ntp.c
+++ b/kernel/time/ntp.c
@@ -441,7 +441,6 @@ int second_overflow(unsigned long secs)
 		break;
 	}
 
-
 	/* Bump the maxerror field */
 	time_maxerror += MAXFREQ / NSEC_PER_USEC;
 	if (time_maxerror > NTP_PHASE_LIMIT) {


### PR DESCRIPTION
a completely trivial patch to remove a completely redundant blank line.
