### PR TITLE
ALSA: Missing ;

### DIFF
--- a/sound/usb/misc/ua101.c
+++ b/sound/usb/misc/ua101.c
@@ -1359,7 +1359,7 @@ static void ua101_disconnect(struct usb_interface *interface)
 	snd_card_disconnect(ua->card);
 
 	/* make sure that there are no pending USB requests */
-	list_for_each(midi, &ua->midi_list)
+	list_for_each(midi, &ua->midi_list);
 		snd_usbmidi_disconnect(midi);
 	abort_alsa_playback(ua);
 	abort_alsa_capture(ua);


### PR DESCRIPTION
Fixes: RT-Linux-Hdaudio-5.18 won't compile because of missing ;
