### PR TITLE
Add auto detection of the ds1307 device on the I2C

### DIFF
--- a/drivers/rtc/rtc-ds1307.c
+++ b/drivers/rtc/rtc-ds1307.c
@@ -177,6 +177,12 @@ static const struct i2c_device_id ds1307_id[] = {
 };
 MODULE_DEVICE_TABLE(i2c, ds1307_id);
 
+static struct i2c_board_info i2c_ds1307_info[] __initdata = {
+	{
+		I2C_BOARD_INFO("ds1307", 0x68),
+	}
+};
+
 /*----------------------------------------------------------------------*/
 
 #define BLOCK_DATA_MAX_TRIES 10
@@ -320,6 +326,9 @@ static void ds1307_work(struct work_struct *work)
 	struct i2c_client	*client;
 	struct mutex		*lock;
 	int			stat, control;
+	
+	i2c_register_board_info(1, i2c_ds1307_info,
+			ARRAY_SIZE(i2c_ds1307_info));
 
 	ds1307 = container_of(work, struct ds1307, work);
 	client = ds1307->client;


### PR DESCRIPTION
Code should add instructions to kernel to auto-detect the presence of ds1307 device on I2C bus on address 0x68 and in case it is found auto assign it. The main drive is to make sure that devices (like Pi) do have correct time before init process is started thus make sure that all daemons have correct time during startup phase. I'm pretty sure that the code added is wrong, jsut don t knwo whom to contact to get help to add this functionality :) I've reused parts from the DOC: https://www.kernel.org/doc/Documentation/i2c/instantiating-devices
