### PR TITLE
option: Inventec Velocity (V HSDPA) support

### DIFF
--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -486,6 +486,10 @@ static void option_instat_callback(struct urb *urb);
 #define INOVIA_VENDOR_ID			0x20a6
 #define INOVIA_SEW858				0x1105
 
+/* Inventec */
+#define INVENTEC_VENDOR_ID      0x0537
+#define INVENTEC_VELOCITY     0xb000
+
 /* some devices interfaces need special handling due to a number of reasons */
 enum option_blacklist_reason {
 		OPTION_BLACKLIST_NONE = 0,
@@ -601,6 +605,7 @@ static const struct usb_device_id option_ids[] = {
 	{ USB_DEVICE(QUANTA_VENDOR_ID, QUANTA_PRODUCT_GKE) },
 	{ USB_DEVICE(QUANTA_VENDOR_ID, QUANTA_PRODUCT_GLE) },
 	{ USB_DEVICE(QUANTA_VENDOR_ID, 0xea42),
+  { USB_DEVICE(INVENTEC_VENDOR_ID, INVENTEC_VELOCITY) },
 		.driver_info = (kernel_ulong_t)&net_intf4_blacklist },
 	{ USB_DEVICE_AND_INTERFACE_INFO(HUAWEI_VENDOR_ID, 0x1c05, USB_CLASS_COMM, 0x02, 0xff) },
 	{ USB_DEVICE_AND_INTERFACE_INFO(HUAWEI_VENDOR_ID, 0x1c1f, USB_CLASS_COMM, 0x02, 0xff) },


### PR DESCRIPTION
Added Inventec Velocity modem IDs to option driver as it supports this device. It is a modem found in Kohjinsha SC3-VHB.
