### PR TITLE
Ignore diagonals for iMON PAD in keyboard mode

### DIFF
--- a/drivers/media/rc/imon.c
+++ b/drivers/media/rc/imon.c
@@ -1407,6 +1407,17 @@ static void imon_pad_to_keys(struct imon_context *ictx, unsigned char *buf)
 			scancode = be32_to_cpu(*((u32 *)buf));
 		} else {
 			/*
+			 * For users without stabilized, just ignore any value getting
+			 * to close to the diagonal.
+			 */
+			if ((abs(rel_y) < 2 && abs(rel_x) < 2) ||
+				abs(abs(rel_y) - abs(rel_x)) < 2 ) {
+				spin_lock_irqsave(&ictx->kc_lock, flags);
+				ictx->kc = KEY_UNKNOWN;
+				spin_unlock_irqrestore(&ictx->kc_lock, flags);
+				return;
+			}
+			/*
 			 * Hack alert: instead of using keycodes, we have
 			 * to use hard-coded scancodes here...
 			 */


### PR DESCRIPTION
For user with an iMON PAD Remote control, the keyboard mode is very touchy and almost useless with XBMC. Event with stabilized() algorithm the behaviour is unexpected. To make it less touchy, I make it ignore any value too close to the diagonals.
