### PR TITLE
scripts/tags.sh: Fix regex syntax for etags.

### DIFF
--- a/scripts/tags.sh
+++ b/scripts/tags.sh
@@ -254,14 +254,14 @@ emacs()
 	--regex='/__CLEARPAGEFLAG_NOOP(\([^,)]*\).*/__ClearPage\1/' \
 	--regex='/TESTCLEARFLAG_FALSE(\([^,)]*\).*/TestClearPage\1/' \
 	--regex='/__TESTCLEARFLAG_FALSE(\([^,)]*\).*/__TestClearPage\1/' \
-	--regex='/TESTPCGFLAG\(([^,)]*).*/PageCgroup\1/'	\
-	--regex='/SETPCGFLAG\(([^,)]*).*/SetPageCgroup\1/'	\
-	--regex='/CLEARPCGFLAG\(([^,)]*).*/ClearPageCgroup\1/'	\
-	--regex='/TESTCLEARPCGFLAG\(([^,)]*).*/TestClearPageCgroup\1/' \
+	--regex='/TESTPCGFLAG(\([^,)]*\).*/PageCgroup\1/'	\
+	--regex='/SETPCGFLAG(\([^,)]*\).*/SetPageCgroup\1/'	\
+	--regex='/CLEARPCGFLAG(\([^,)]*\).*/ClearPageCgroup\1/'	\
+	--regex='/TESTCLEARPCGFLAG(\([^,)]*\).*/TestClearPageCgroup\1/' \
 	--regex='/_PE(\([^,)]*\).*/PEVENT_ERRNO__\1/'		\
 	--regex='/PCI_OP_READ(\([a-z]*[a-z]\).*[1-4])/pci_bus_read_config_\1/' \
-	--regex='/PCI_OP_WRITE(\([a-z]*[a-z]\).*[1-4])/pci_bus_write_config_\1/'\
-	--regex='/DEFINE_HASHTABLE\((\w*)/\1/v/'
+	--regex='/PCI_OP_WRITE(\([a-z]*[a-z]\).*[1-4])/pci_bus_write_config_\1/' \
+	--regex='/DEFINE_HASHTABLEE(\([a-z]*[a-z]\)/\1/'
 
 	all_kconfigs | xargs $1 -a                              \
 	--regex='/^[ \t]*\(\(menu\)*config\)[ \t]+\([a-zA-Z0-9_]+\)/\3/'


### PR DESCRIPTION
Fix regexp syntax to run TAGS command correctly regarding below patches.
- [79c704a] add regular expression replacement pattern for memcg
- [3005286] add pattern for DEFINE_HASHTABLE

Signed-off-by: Sungwook Jung rhapsodist@gmail.com
