### PR TITLE
Update cfi_cmdset_0002.c

### DIFF
--- a/drivers/mtd/chips/cfi_cmdset_0002.c
+++ b/drivers/mtd/chips/cfi_cmdset_0002.c
@@ -1625,14 +1625,14 @@ static int __xipram do_write_oneword(struct map_info *map, struct flchip *chip,
 			continue;
 		}
 
-		if (time_after(jiffies, timeo) && !chip_ready(map, adr)){
+		if (time_after(jiffies, timeo) && !chip_good(map, adr, datum)){
 			xip_enable(map, chip, adr);
 			printk(KERN_WARNING "MTD %s(): software timeout\n", __func__);
 			xip_disable(map, chip, adr);
 			break;
 		}
 
-		if (chip_ready(map, adr))
+		if (chip_good(map, adr, datum))
 			break;
 
 		/* Latency issues. Drop the lock, wait a while and retry */
@@ -1874,10 +1874,10 @@ static int __xipram do_write_buffer(struct map_info *map, struct flchip *chip,
 			continue;
 		}
 
-		if (time_after(jiffies, timeo) && !chip_ready(map, adr))
+		if (time_after(jiffies, timeo) && !chip_good(map, adr, datum))
 			break;
 
-		if (chip_ready(map, adr)) {
+		if (chip_good(map, adr, datum)) {
 			xip_enable(map, chip, adr);
 			goto op_done;
 		}
@@ -2288,7 +2288,7 @@ static int __xipram do_erase_chip(struct map_info *map, struct flchip *chip)
 			chip->erase_suspended = 0;
 		}
 
-		if (chip_ready(map, adr))
+		if (chip_good(map, adr, map_word_ff(map)))
 			break;
 
 		if (time_after(jiffies, timeo)) {
@@ -2377,7 +2377,7 @@ static int __xipram do_erase_oneblock(struct map_info *map, struct flchip *chip,
 			chip->erase_suspended = 0;
 		}
 
-		if (chip_ready(map, adr)) {
+		if (chip_good(map, adr, map_word_ff(map))) {
 			xip_enable(map, chip, adr);
 			break;
 		}


### PR DESCRIPTION
# Issue description:

During writing the Linux Kernel image on /dev/mtdX device the burning is failed due to I/O write or erase error:

Erasing blocks: 6/12 (50%)
While erasing blocks 0x000a0000-0x000c0000 on /dev/mtd1: Input/output error
Burning the /persistent/ISF.img image on /dev/mtd1 failed.

When doing erase, writing or verifying using FLASHCP program, the cfi mtd functions of Linux Kernel MTD driver can returns too early. The function chip_ready() return OK status while the actual writing or erasing is not finished on NOR flash device. It leads to I/O error and fail in writing, erasing or verifying of the data during working with MTD devices.

When the issue with writing is reproduced we compared the data of LinuxKERNEL.img and the data which was written on the /dev/mtdX device:
dd if=/dev/mtd3 bs=2367008 count=1 > /persistent/dest.buf
hexdump /persistent/dest.buf > /persistent/dest.hex
hexdump /persistent/LinuxKERNEL.img > /persistent/source.hex
diff -purN /persistent/dest.hex /persistent/source.hex

And it was observed that the driver didn't write some blocks at all (0xffff instead of real data in some places). Flash driver skip writing or hasn't been finished it during the specific time.

I found that in Internet I am not alone in this world, but I didn't find some solution for this problem which doesn't lead to increasing of the time of writing.  So I investigate the writing and found that there is no any check that the data is really was written on the Flash. So the proposed solution is to compare the given last byte with written one. We have run a long stubility during several weeks on our side with Switch Board using writing on NOR flash and the problem is not reproduced.
# FREQUENCY:

1%
The I/O error appears about 1 time during 3-4 hours writing on NOR flash. But it was not possible to determine exactly at what time the issue can happen.
# SYSTEM IMPACT:

fails to write/erase on NOR flash
# FIX DESCRIPTION:

Wait until the following checks return positive results during writing/erasing on NOR Flash:
1. read the data/status from the device (checking status of the NOR Flash: busy, timeout or ok(data)) return ok;
2. check the last byte of given buffer data is written in case of WRITE or the last map word is erased in case of ERASE.
# TEST DESCRIPTION:

Start writing some data on NOR FLASH (mtd device) using flashcp or start erasing using flash_erase.
