### PR TITLE
Small comment correction

### DIFF
--- a/include/uapi/linux/blktrace_api.h
+++ b/include/uapi/linux/blktrace_api.h
@@ -98,7 +98,7 @@ enum blktrace_notify {
 struct blk_io_trace {
 	__u32 magic;		/* MAGIC << 8 | version */
 	__u32 sequence;		/* event number */
-	__u64 time;		/* in microseconds */
+	__u64 time;		/* in nanoseconds */
 	__u64 sector;		/* disk offset */
 	__u32 bytes;		/* transfer length */
 	__u32 action;		/* what happened */


### PR DESCRIPTION
The time field in blk_io_trace is in nanoseconds. Correct the comment from microseconds to nanoseconds.
The field was once in microseconds, but was changed to nanoseconds in commit 6c051ce0307526adec32a847f0daa1af2124f0a9 on March 25, 2009. Update the comment to match a 5-year-old reality.
