### PR TITLE
Minor improvement for smsc95xx netusb driver performance.

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -1833,7 +1833,9 @@ static struct sk_buff *smsc95xx_tx_fixup(struct usbnet *dev,
 {
 	bool csum = skb->ip_summed == CHECKSUM_PARTIAL;
 	int overhead = csum ? SMSC95XX_TX_OVERHEAD_CSUM : SMSC95XX_TX_OVERHEAD;
-	u32 tx_cmd_a, tx_cmd_b;
+	struct tx_commands_t {
+		u32 cmd_a, cmd_b, csum_preamble;
+	}tx_cmds;
 
 	/* We do not advertise SG, so skbs should be already linearized */
 	BUG_ON(skb_shinfo(skb)->nr_frags);
@@ -1858,26 +1860,25 @@ static struct sk_buff *smsc95xx_tx_fixup(struct usbnet *dev,
 				+ skb->csum_offset)) = csum_fold(calc);
 
 			csum = false;
+			overhead = SMSC95XX_TX_OVERHEAD;
 		} else {
-			u32 csum_preamble = smsc95xx_calc_csum_preamble(skb);
+			tx_cmds.csum_preamble = smsc95xx_calc_csum_preamble(skb);
 			skb_push(skb, 4);
-			cpu_to_le32s(&csum_preamble);
-			memcpy(skb->data, &csum_preamble, 4);
+			cpu_to_le32s(&tx_cmds.csum_preamble);
 		}
 	}
 
-	skb_push(skb, 4);
-	tx_cmd_b = (u32)(skb->len - 4);
-	if (csum)
-		tx_cmd_b |= TX_CMD_B_CSUM_ENABLE;
-	cpu_to_le32s(&tx_cmd_b);
-	memcpy(skb->data, &tx_cmd_b, 4);
-
-	skb_push(skb, 4);
-	tx_cmd_a = (u32)(skb->len - 8) | TX_CMD_A_FIRST_SEG_ |
+	tx_cmds.cmd_a = (u32)(skb->len) | TX_CMD_A_FIRST_SEG_ |
 		TX_CMD_A_LAST_SEG_;
-	cpu_to_le32s(&tx_cmd_a);
-	memcpy(skb->data, &tx_cmd_a, 4);
+	cpu_to_le32s(&tx_cmds.cmd_a);
+	
+	tx_cmds.cmd_b = (u32)(skb->len);
+	if (csum)
+		tx_cmds.cmd_b |= TX_CMD_B_CSUM_ENABLE;
+	cpu_to_le32s(&tx_cmds.cmd_b);
+	
+	skb_push(skb, 8);
+	memcpy(skb->data, &tx_cmds, overhead);
 
 	return skb;
 }


### PR DESCRIPTION
Reduce number of memcpy's by 1-2 improve transmit performance by 2-4%, or reduce cpu usage on a comparable value.
