### PR TITLE
Replace gzip/bzip2 with xz in README

### DIFF
--- a/README
+++ b/README
@@ -62,11 +62,7 @@ INSTALLING the kernel source:
    directory where you have permissions (eg. your home directory) and
    unpack it:
 
-     gzip -cd linux-3.X.tar.gz | tar xvf -
-
-   or
-
-     bzip2 -dc linux-3.X.tar.bz2 | tar xvf -
+     xz -cd linux-3.X.tar.gz | tar xvf -
 
    Replace "X" with the version number of the latest kernel.
 
@@ -80,11 +76,7 @@ INSTALLING the kernel source:
    install by patching, get all the newer patch files, enter the
    top level directory of the kernel source (linux-3.X) and execute:
 
-     gzip -cd ../patch-3.x.gz | patch -p1
-
-   or
-
-     bzip2 -dc ../patch-3.x.bz2 | patch -p1
+     xz -cd ../patch-3.x.gz | patch -p1
 
    Replace "x" for all versions bigger than the version "X" of your current
    source tree, _in_order_, and you should be ok.  You may want to remove


### PR DESCRIPTION
Kernel tarballs are only compressed with xz now, gzip and bzip2 are redundant.