### PR TITLE
Fix several "functoin" -> "function" typos

### DIFF
--- a/drivers/scsi/isci/task.c
+++ b/drivers/scsi/isci/task.c
@@ -609,7 +609,7 @@ out:
 
 /**
  * isci_task_abort_task_set() - This function is one of the SAS Domain Template
- *    functions. This is one of the Task Management functoins called by libsas,
+ *    functions. This is one of the Task Management functions called by libsas,
  *    to abort all task for the given lun.
  * @d_device: This parameter specifies the domain device associated with this
  *    request.
@@ -627,7 +627,7 @@ int isci_task_abort_task_set(
 
 /**
  * isci_task_clear_aca() - This function is one of the SAS Domain Template
- *    functions. This is one of the Task Management functoins called by libsas.
+ *    functions. This is one of the Task Management functions called by libsas.
  * @d_device: This parameter specifies the domain device associated with this
  *    request.
  * @lun: This parameter specifies the lun	 associated with this request.
@@ -645,7 +645,7 @@ int isci_task_clear_aca(
 
 /**
  * isci_task_clear_task_set() - This function is one of the SAS Domain Template
- *    functions. This is one of the Task Management functoins called by libsas.
+ *    functions. This is one of the Task Management functions called by libsas.
  * @d_device: This parameter specifies the domain device associated with this
  *    request.
  * @lun: This parameter specifies the lun	 associated with this request.

--- a/fs/ext3/dir.c
+++ b/fs/ext3/dir.c
@@ -304,7 +304,7 @@ struct fname {
 };
 
 /*
- * This functoin implements a non-recursive way of freeing all of the
+ * This function implements a non-recursive way of freeing all of the
  * nodes in the red-black tree.
  */
 static void free_rb_tree_fname(struct rb_root *root)

--- a/fs/ext4/dir.c
+++ b/fs/ext4/dir.c
@@ -345,7 +345,7 @@ struct fname {
 };
 
 /*
- * This functoin implements a non-recursive way of freeing all of the
+ * This function implements a non-recursive way of freeing all of the
  * nodes in the red-black tree.
  */
 static void free_rb_tree_fname(struct rb_root *root)


### PR DESCRIPTION
Just a relatively common typo I noticed while browsing the linux source.