### PR TITLE
Patch for LZ4 decompression bug

### DIFF
--- a/lib/lz4/lz4_decompress.c
+++ b/lib/lz4/lz4_decompress.c
@@ -140,8 +140,12 @@ static int lz4_uncompress(const char *source, char *dest, int osize)
 			/* Error: request to write beyond destination buffer */
 			if (cpy > oend)
 				goto _output_error;
+	#if LZ4_ARCH64	
+			if ((ref + COPYLENGTH) > oend)
+	#else		
 			if ((ref + COPYLENGTH) > oend ||
-					(op + COPYLENGTH) > oend)
+				(op + COPYLENGTH) > oend)
+	#endif				
 				goto _output_error;
 			LZ4_SECURECOPY(ref, op, (oend - COPYLENGTH));
 			while (op < cpy)
@@ -266,7 +270,13 @@ static int lz4_uncompress_unknownoutputsize(const char *source, char *dest,
 		if (cpy > oend - COPYLENGTH) {
 			if (cpy > oend)
 				goto _output_error; /* write outside of buf */
-
+#if LZ4_ARCH64
+			if ((ref + COPYLENGTH) > oend)
+#else			
+			if ((ref + COPYLENGTH) > oend ||
+				(op + COPYLENGTH) > oend)
+#endif
+				goto _output_error;
 			LZ4_SECURECOPY(ref, op, (oend - COPYLENGTH));
 			while (op < cpy)
 				*op++ = *ref++;


### PR DESCRIPTION
Sorry if i've misformatted this patch, i'm not terribly comfortable with github :(

The issue (and patch by Krzysztof Kolasa emerged here https://lkml.org/lkml/2015/4/3/453)

64bit kernels using the latest upstream source and compressed with LZ4 (mine included) are unable to decompress the image and simply halt saying 
"Decoding failed
 -- System halted"

The attached patch by Krzysztof successfully solved this issue, but there was a problem with its formatting, so it wasn't accepted. I'm hoping a suitable patch can be made (if i've horribly mucked this up) before the 4.1 kernel reaches stability, even better if it could make it in before this weekend's next -rc bump.
I cannot comment on the suitability or style of the code itself, i am simply trying to push it forward, since it's quite important for fellow LZ4 users.

Thank you in advance!