### PR TITLE
Spelling mistake in ftrace.c

### DIFF
--- a/kernel/trace/ftrace.c
+++ b/kernel/trace/ftrace.c
@@ -2857,7 +2857,7 @@ static int ftrace_update_code(struct module *mod, struct ftrace_page *new_pgs)
 			/*
 			 * If the tracing is enabled, go ahead and enable the record.
 			 *
-			 * The reason not to enable the record immediatelly is the
+			 * The reason not to enable the record immediately is the
 			 * inherent check of ftrace_make_nop/ftrace_make_call for
 			 * correct previous instructions.  Making first the NOP
 			 * conversion puts the module to the correct state, thus


### PR DESCRIPTION
Fixed a spelling mistake ('immediately' has one l)
