### PR TITLE
iio:ak8975 : Fixed checkpatch warning

### DIFF
--- a/Documentation/devicetree/bindings/iio/magnetometer/ak8975.txt
+++ b/Documentation/devicetree/bindings/iio/magnetometer/ak8975.txt
@@ -16,3 +16,13 @@ ak8975@0c {
         reg = <0x0c>;
         gpios = <&gpj0 7 0>;
 };
+
+Valid compatible strings:
+- asahi-kasei,ak8975
+- ak8975
+- asahi-kasei,ak8963
+- ak8963
+- asahi-kasei,ak09911
+- ak09911
+- asahi-kasei,ak09912
+- ak09912


### PR DESCRIPTION
This adds support for the AsahiKASEI magnetometer sensor compatible string.