### PR TITLE
Add the missing PCIID for MSI (maybe not only) R7 370

### DIFF
--- a/drivers/gpu/drm/radeon/si_dpm.c
+++ b/drivers/gpu/drm/radeon/si_dpm.c
@@ -2927,6 +2927,7 @@ static struct si_dpm_quirk si_dpm_quirk_list[] = {
 	{ PCI_VENDOR_ID_ATI, 0x6810, 0x1462, 0x3036, 0, 120000 },
 	{ PCI_VENDOR_ID_ATI, 0x6811, 0x174b, 0xe271, 0, 120000 },
 	{ PCI_VENDOR_ID_ATI, 0x6810, 0x174b, 0xe271, 85000, 90000 },
+	{ PCI_VENDOR_ID_ATI, 0x6811, 0x1462, 0x2015, 0, 120000 },
 	{ 0, 0, 0, 0 },
 };
 


### PR DESCRIPTION
There's a missing PCIID for MSI R7 370 Armor 2X (probably some other cards). Without it the screen will turn black (there would be signal, but system hangs if it happens) or just become filled with vertical white stripes - note that it happens at the modesetting stage. There's a way to make it work without this patch by disabling dpm (dpm=0) and/or disabling modesetting (nomodeset) (note that disabling modesetting will make your system work for a while, but it will hang after a few minutes). Adding this line/ID will make the GPU function as expected, without functionaluty loss/instability.