### PR TITLE
Added bc in the list of dependencies to have an exhaustive list.

### DIFF
--- a/Documentation/Changes
+++ b/Documentation/Changes
@@ -44,7 +44,7 @@ o  grub                   0.93                    # grub --version || grub-insta
 o  mcelog                 0.6                     # mcelog --version
 o  iptables               1.4.2                   # iptables -V
 o  openssl & libcrypto    1.0.1k                  # openssl version
-
+o  bc                     1.06.95                 # bc --version
 
 Kernel compilation
 ==================


### PR DESCRIPTION
I created a docker container based on the list of dependencies and it was missing bc.
I spotted out it is later in the documentation but it would be more convenient to have it in the list as well as it seems to be the only one missing when using the default configuration on x86_64.
