### PR TITLE
drivers/of/irq.c : correct a typing error

### DIFF
--- a/drivers/of/irq.c
+++ b/drivers/of/irq.c
@@ -250,7 +250,7 @@ int of_irq_parse_raw(const __be32 *addr, struct of_phandle_args *out_irq)
 			goto fail;
 
 		/*
-		 * Successfully parsed an interrrupt-map translation; copy new
+		 * Successfully parsed an interrupt-map translation; copy new
 		 * interrupt specifier into the out_irq structure
 		 */
 		match_array = imap - newaddrsize - newintsize;


### PR DESCRIPTION
There is a typing error "interrrupt"
So, I correct this to "interrupt"

Signed-off-by: Kyuha Hwang <gmonster@jjssm.org>