### PR TITLE
Fixing infoleak via FBIOGET_VBLANK IOCTL CALL

### DIFF
--- a/drivers/media/platform/vivid/vivid-osd.c
+++ b/drivers/media/platform/vivid/vivid-osd.c
@@ -84,7 +84,8 @@ static int vivid_fb_ioctl(struct fb_info *info, unsigned cmd, unsigned long arg)
 	switch (cmd) {
 	case FBIOGET_VBLANK: {
 		struct fb_vblank vblank;
-
+		
+		memset(&vblank, 0, sizeof(vblank));
 		vblank.flags = FB_VBLANK_HAVE_COUNT | FB_VBLANK_HAVE_VCOUNT |
 			FB_VBLANK_HAVE_VSYNC;
 		vblank.count = 0;


### PR DESCRIPTION
This was fixed on the repo in git.kernel.org (CVE-2015-7884) but not here.