### PR TITLE
4.4-rc1 broken perf tool.

### DIFF
--- a/tools/include/linux/list.h
+++ b/tools/include/linux/list.h
@@ -85,8 +85,10 @@ static inline void list_add_tail(struct list_head *new, struct list_head *head)
  */
 static inline void __list_del(struct list_head * prev, struct list_head * next)
 {
-	next->prev = prev;
-	WRITE_ONCE(prev->next, next);
+	if(next)
+		next->prev = prev;
+	if(prev)
+		WRITE_ONCE(prev->next, next);
 }
 
 /**


### PR DESCRIPTION
reproduce:

lzto@objd ~ $ ~/linux/tools/perf/perf record -I -e intel_pt/tsc=1,noretcomp=1/u /bin/ls
lzto@objd ~ $ ~/linux/tools/perf/perf script  -F event,comm,pid,tid,time,addr,ip,sym,dso,iregs
Segmentation fault
lzto@objd ~ $

Upon further investigation, it seems commit 747a9b0a08ae300b99b8aa7861bd3609f3b3e782 breaks perf tool.

__list_del(): tools/include/linux/list.h does not check null pointer dereference