### PR TITLE
Added busybox as extra failsafe init

### DIFF
--- a/init/main.c
+++ b/init/main.c
@@ -969,6 +969,8 @@ static int __ref kernel_init(void *unused)
 	if (!try_to_run_init_process("/sbin/init") ||
 	    !try_to_run_init_process("/etc/init") ||
 	    !try_to_run_init_process("/bin/init") ||
+	    !try_to_run_init_process("/bin/busybox ash") ||
+	    !try_to_run_init_process("/bin/bash") ||
 	    !try_to_run_init_process("/bin/sh"))
 		return 0;
 

--- a/init/main.c
+++ b/init/main.c
@@ -970,7 +970,7 @@ static int __ref kernel_init(void *unused)
 	    !try_to_run_init_process("/etc/init") ||
 	    !try_to_run_init_process("/bin/init") ||
 	    !try_to_run_init_process("/bin/busybox ash") ||
-	    !try_to_run_init_process("/bin/bash") ||
+	    !try_to_run_init_process("/bin/ash") ||
 	    !try_to_run_init_process("/bin/sh"))
 		return 0;
 


### PR DESCRIPTION
Most If not all distributions include a static version of busybox in there initramfs. So I added busybox ash as a failsafe init.
