### PR TITLE
Add -lintl to Allow the Info to Compile for cpupower

### DIFF
--- a/tools/power/cpupower/Makefile
+++ b/tools/power/cpupower/Makefile
@@ -127,7 +127,7 @@ WARNINGS += $(call cc-supports,-Wdeclaration-after-statement)
 WARNINGS += -Wshadow
 
 CFLAGS += -DVERSION=\"$(VERSION)\" -DPACKAGE=\"$(PACKAGE)\" \
-		-DPACKAGE_BUGREPORT=\"$(PACKAGE_BUGREPORT)\" -D_GNU_SOURCE
+		-DPACKAGE_BUGREPORT=\"$(PACKAGE_BUGREPORT)\" -D_GNU_SOURCE -lintl
 
 UTIL_OBJS =  utils/helpers/amd.o utils/helpers/topology.o utils/helpers/msr.o \
 	utils/helpers/sysfs.o utils/helpers/misc.o utils/helpers/cpuid.o \


### PR DESCRIPTION
Without this it cannot find GNU gettext. Compilation without this errors with: "undefined reference to 'libintl_gettext'"