### PR TITLE
Added code for custom file prefetching

### DIFF
--- a/fs/nfs/Makefile
+++ b/fs/nfs/Makefile
@@ -7,7 +7,7 @@ obj-$(CONFIG_NFS_FS) += nfs.o
 CFLAGS_nfstrace.o += -I$(src)
 nfs-y 			:= client.o dir.o file.o getroot.o inode.o super.o \
 			   direct.o pagelist.o read.o symlink.o unlink.o \
-			   write.o namespace.o mount_clnt.o nfstrace.o
+			   write.o namespace.o mount_clnt.o nfstrace.o prefetch.o
 nfs-$(CONFIG_ROOT_NFS)	+= nfsroot.o
 nfs-$(CONFIG_SYSCTL)	+= sysctl.o
 nfs-$(CONFIG_NFS_FSCACHE) += fscache.o fscache-index.o

--- a/fs/nfs/nfs4_fs.h
+++ b/fs/nfs/nfs4_fs.h
@@ -473,6 +473,7 @@ extern char nfs4_client_id_uniquifier[NFS4_CLIENT_ID_UNIQ_LEN];
 /* nfs4sysctl.c */
 #ifdef CONFIG_SYSCTL
 int nfs4_register_sysctl(void);
+int prefetch_register_sysctl(void);
 void nfs4_unregister_sysctl(void);
 #else
 static inline int nfs4_register_sysctl(void)

--- a/fs/nfs/nfs4super.c
+++ b/fs/nfs/nfs4super.c
@@ -334,6 +334,10 @@ static int __init init_nfs_v4(void)
 	if (err)
 		goto out2;
 
+	err = prefetch_register_sysctl();
+	if (err)
+		goto out2;
+
 	register_nfs_version(&nfs_v4);
 	return 0;
 out2:

--- a/fs/nfs/prefetch.c
+++ b/fs/nfs/prefetch.c
@@ -1,0 +1,53 @@
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/sched.h>
+#include <linux/mm.h>
+#include <linux/nfs_fs.h>
+#include <linux/nfs_fs_sb.h>
+#include <linux/in6.h>
+#include <linux/seq_file.h>
+#include <linux/slab.h>
+#include <linux/sysctl.h>
+
+#include "internal.h"
+#include "iostat.h"
+#include "fscache.h"
+
+
+static int global_var;
+static int min_val = 0;
+static int max_val = 5;
+
+static struct ctl_table prefetch_child_table[] = {
+{
+	//.ctl_name = CTL_UNNUMBERED,
+	.procname = "prefetch",
+	.maxlen = sizeof(int),
+	.mode = 0644,
+	.data = &global_var,
+	.proc_handler = &proc_dointvec_minmax,
+	.extra1 = &min_val,
+	.extra2 = &max_val,
+},
+{}
+};
+
+static struct ctl_table prefetch_parent_table[] = {
+{
+	//.ctl_name = CTL_KERN,
+	.procname = "kernel",
+	.mode = 0555,
+	.child = prefetch_child_table,
+},
+{}
+};
+
+int prefetch_register_sysctl(void)
+{
+	/* register the above sysctl */
+	if (!register_sysctl_table(prefetch_parent_table)) {
+		printk(KERN_ALERT "Error: Failed to register sample_parent_table\n");
+		return -EFAULT;
+	}
+	return 0;
+}

--- a/mm/filemap.c
+++ b/mm/filemap.c
@@ -1760,6 +1760,12 @@ generic_file_read_iter(struct kiocb *iocb, struct iov_iter *iter)
 	loff_t *ppos = &iocb->ki_pos;
 	loff_t pos = *ppos;
 
+	if (file->f_path.dentry) {
+		if (strstr(file->f_path.dentry->d_name.name, ".tar")) {
+			printk("RDTSC=%llu\n", (unsigned long long)rdtsc());
+		}
+	}
+
 	if (iocb->ki_flags & IOCB_DIRECT) {
 		struct address_space *mapping = file->f_mapping;
 		struct inode *inode = mapping->host;


### PR DESCRIPTION
This file prefetching algorithm works on the basis of access patterns of a given
file type and the cache pressure. This patch adds the code for measuring the
cache pressure, identify filetype and get the access pattern of that file.
This patch also sets up a sysctl variable to change the prefetching algorihtm.