### PR TITLE
Adjust the speed on the TUN/TAP interface

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -2397,7 +2397,7 @@ static int tun_get_settings(struct net_device *dev, struct ethtool_cmd *cmd)
 {
 	cmd->supported		= 0;
 	cmd->advertising	= 0;
-	ethtool_cmd_speed_set(cmd, SPEED_10);
+	ethtool_cmd_speed_set(cmd, SPEED_100);
 	cmd->duplex		= DUPLEX_FULL;
 	cmd->port		= PORT_TP;
 	cmd->phy_address	= 0;


### PR DESCRIPTION
SPEED_10 is almost unheard of in modern Networking. Since the TUN/TAP interface can exceed this value it breaks tools like sar that use the port's speed to calculate interface utilization. SPEED_100 is a more realistic number that you might see on a modern network, though SPEED_1000 is becoming more common now.