### PR TITLE
Added usb-device desriptor for Sagem USB-Serial Controller

### DIFF
--- a/drivers/usb/class/cdc-acm.c
+++ b/drivers/usb/class/cdc-acm.c
@@ -1706,6 +1706,9 @@ static const struct usb_device_id acm_ids[] = {
 	{ USB_DEVICE(0x079b, 0x000f), /* BT On-Air USB MODEM */
 	.driver_info = NO_UNION_NORMAL, /* has no union descriptor */
 	},
+	{ USB_DEVICE(0x079b, 0x0028), /* Sagem USB-Serial Controller, Ingenico EFT30 Sagem Terminal */
+	.driver_info = NO_UNION_NORMAL, /* has no union descriptor */
+	},
 	{ USB_DEVICE(0x0ace, 0x1602), /* ZyDAS 56K USB MODEM */
 	.driver_info = SINGLE_RX_URB,
 	},


### PR DESCRIPTION
Changes to be committed:
	modified:   drivers/usb/class/cdc-acm.c