### PR TITLE
Remove unresolved cache limit of 10

### DIFF
--- a/net/ipv4/ipmr.c
+++ b/net/ipv4/ipmr.c
@@ -1039,8 +1039,7 @@ static int ipmr_cache_unresolved(struct mr_table *mrt, vifi_t vifi,
 
 	if (!found) {
 		/* Create a new entry if allowable */
-		if (atomic_read(&mrt->cache_resolve_queue_len) >= 10 ||
-		    (c = ipmr_cache_alloc_unres()) == NULL) {
+		if ((c = ipmr_cache_alloc_unres()) == NULL) {
 			spin_unlock_bh(&mfc_unres_lock);
 
 			kfree_skb(skb);


### PR DESCRIPTION
The maximum number of unresolved multicast groups in the Multicast Routing Table (MRT) is limited to 10 or less within the ipmr_cache_unresolved function. The unresolved cache is flushed and what seems to be a statically random set of 10 or less unresolved multicast groups are rebuilt in the MRT every jiffies+HZ/10.  In an environment where there are a great deal more than 10 multicast source streams and only a few are actually joined a great deal more than 10 possible unresolved entries may exist and many cache_misses are encountered.  A recompiled Linux kernel, using this patch quickly creates multicast routes from a complete cache of unresolved entries.  The 10 unresolved cache limit results in a denial of service, if a host sends 20 or greater streams to an interface serviced by pimd (ie if a host sends 100 multicast streams, there is a 1 in 10 chance that a cache hit would be encountered with the existing code.)