### PR TITLE
Disable hw TSO for atl1e atheros card

### DIFF
--- a/drivers/net/ethernet/atheros/atl1e/atl1e_main.c
+++ b/drivers/net/ethernet/atheros/atl1e/atl1e_main.c
@@ -2274,7 +2274,7 @@ static int atl1e_init_netdev(struct net_device *netdev, struct pci_dev *pdev)
 	netdev->watchdog_timeo = AT_TX_WATCHDOG;
 	atl1e_set_ethtool_ops(netdev);
 
-	netdev->hw_features = NETIF_F_SG | NETIF_F_HW_CSUM | NETIF_F_TSO |
+	netdev->hw_features = NETIF_F_SG | NETIF_F_HW_CSUM |
 			      NETIF_F_HW_VLAN_CTAG_RX;
 	netdev->features = netdev->hw_features | NETIF_F_HW_VLAN_CTAG_TX;
 	/* not enabled by default */


### PR DESCRIPTION
So maybe i'm the only one that is still using this Ethernet card in the world but after opening a bug a lot time ago my patch was not merged: this card has a broken hardware as described [here](https://bugzilla.kernel.org/show_bug.cgi?id=113501) it causes a lot of speed problem.