### PR TITLE
net/bridge: fix dropping packets that moving through bridge interface

### DIFF
--- a/net/bridge/br_netfilter_hooks.c
+++ b/net/bridge/br_netfilter_hooks.c
@@ -399,7 +399,7 @@ bridged_dnat:
 				br_nf_hook_thresh(NF_BR_PRE_ROUTING,
 						  net, sk, skb, skb->dev,
 						  NULL,
-						  br_nf_pre_routing_finish);
+						  br_nf_pre_routing_finish_bridge);
 				return 0;
 			}
 			ether_addr_copy(eth_hdr(skb)->h_dest, dev->dev_addr);


### PR DESCRIPTION
Fix regression introduced by commit c5136b1.
br_nf_pre_routing_finish() calls itself instead of
br_nf_pre_routing_finish_bridge().

Due to this bug reverse path filter drops packets that moving through bridge interface.