### PR TITLE
Fixed punctuation

### DIFF
--- a/samples/trace_events/Makefile
+++ b/samples/trace_events/Makefile
@@ -1,13 +1,13 @@
-# builds the trace events example kernel modules;
+# Builds the trace events example kernel modules;
 # then to use one (as root):  insmod <module_name.ko>
 
-# If you include a trace header outside of include/trace/events
+# If you include a trace header outside of include/trace/events,
 # then the file that does the #define CREATE_TRACE_POINTS must
 # have that tracer file in its main search path. This is because
 # define_trace.h will include it, and must be able to find it from
 # the include/trace directory.
 #
-# Here trace-events-sample.c does the CREATE_TRACE_POINTS.
+# Here, trace-events-sample.c does the CREATE_TRACE_POINTS.
 #
 CFLAGS_trace-events-sample.o := -I$(src)
 


### PR DESCRIPTION
Made the first letter of the first sentence (the 'b' in "builds") capital.

Added missing commas.