### PR TITLE
Documentation/RCU: Fix logic conflict

### DIFF
--- a/Documentation/RCU/whatisRCU.txt
+++ b/Documentation/RCU/whatisRCU.txt
@@ -199,7 +199,7 @@ synchronize_rcu()
 	it is illegal to block or where update-side performance is
 	critically important.
 
-	However, the call_rcu() API should not be used lightly, as use
+	However, the call_rcu() API should be used lightly, as use
 	of the synchronize_rcu() API generally results in simpler code.
 	In addition, the synchronize_rcu() API has the nice property
 	of automatically limiting update rate should grace periods


### PR DESCRIPTION
According to the logic of the following paragraph, call_rcu() should not be used a lot, or "should be used lightly."