### PR TITLE
selftests: fix memory-hotplug test

### DIFF
--- a/tools/testing/selftests/memory-hotplug/mem-on-off-test.sh
+++ b/tools/testing/selftests/memory-hotplug/mem-on-off-test.sh
@@ -22,6 +22,11 @@ prerequisite()
 		echo $msg memory hotplug is not supported >&2
 		exit 0
 	fi
+
+	if ! grep -q 1 $SYSFS/devices/system/memory/memory*/removable; then
+		echo $msg no hot-pluggable memory >&2
+		exit 0
+	fi
 }
 
 #
@@ -39,7 +44,7 @@ hotpluggable_memory()
 	done
 }
 
-hotplaggable_offline_memory()
+hotpluggable_offline_memory()
 {
 	hotpluggable_memory offline
 }
@@ -75,9 +80,12 @@ online_memory_expect_success()
 
 	if ! online_memory $memory; then
 		echo $FUNCNAME $memory: unexpected fail >&2
+		return 1
 	elif ! memory_is_online $memory; then
 		echo $FUNCNAME $memory: unexpected offline >&2
+		return 1
 	fi
+	return 0
 }
 
 online_memory_expect_fail()
@@ -86,9 +94,12 @@ online_memory_expect_fail()
 
 	if online_memory $memory 2> /dev/null; then
 		echo $FUNCNAME $memory: unexpected success >&2
+		return 1
 	elif ! memory_is_offline $memory; then
 		echo $FUNCNAME $memory: unexpected online >&2
+		return 1
 	fi
+	return 0
 }
 
 offline_memory_expect_success()
@@ -97,9 +108,12 @@ offline_memory_expect_success()
 
 	if ! offline_memory $memory; then
 		echo $FUNCNAME $memory: unexpected fail >&2
+		return 1
 	elif ! memory_is_offline $memory; then
 		echo $FUNCNAME $memory: unexpected offline >&2
+		return 1
 	fi
+	return 0
 }
 
 offline_memory_expect_fail()
@@ -108,14 +122,18 @@ offline_memory_expect_fail()
 
 	if offline_memory $memory 2> /dev/null; then
 		echo $FUNCNAME $memory: unexpected success >&2
+		return 1
 	elif ! memory_is_online $memory; then
 		echo $FUNCNAME $memory: unexpected offline >&2
+		return 1
 	fi
+	return 0
 }
 
 error=-12
 priority=0
 ratio=10
+retval=0
 
 while getopts e:hp:r: opt; do
 	case $opt in
@@ -131,6 +149,10 @@ while getopts e:hp:r: opt; do
 		;;
 	r)
 		ratio=$OPTARG
+		if [ "$ratio" -gt 100 ] || [ "$ratio" -lt 0 ]; then
+			echo "The percentage should be an integer within 0~100 range"
+			exit
+		fi
 		;;
 	esac
 done
@@ -143,35 +165,58 @@ fi
 prerequisite
 
 echo "Test scope: $ratio% hotplug memory"
-echo -e "\t online all hotplug memory in offline state"
-echo -e "\t offline $ratio% hotplug memory in online state"
-echo -e "\t online all hotplug memory in offline state"
 
 #
 # Online all hot-pluggable memory
 #
-for memory in `hotplaggable_offline_memory`; do
-	echo offline-online $memory
-	online_memory_expect_success $memory
-done
+hotpluggable_num=`hotpluggable_offline_memory | wc -l`
+echo -e "\t online all hot-pluggable memory in offline state:"
+if [ "$hotpluggable_num" -gt 0 ]; then
+	for memory in `hotpluggable_offline_memory`; do
+		echo "offline->online memory$memory"
+		if ! online_memory_expect_success $memory; then
+			retval=1
+		fi
+	done
+else
+	echo -e "\t\t SKIPPED - no hot-pluggable memory in offline state"
+fi
 
 #
 # Offline $ratio percent of hot-pluggable memory
 #
+hotpluggable_num=`hotpluggable_online_memory | wc -l`
+target=`echo "a=$hotpluggable_num*$ratio; if ( a%100 ) a/100+1 else a/100" | bc`
+echo -e "\t offline $ratio% hot-pluggable memory in online state"
+echo -e "\t trying to offline $target out of $hotpluggable_num memory block(s):"
 for memory in `hotpluggable_online_memory`; do
-	if [ $((RANDOM % 100)) -lt $ratio ]; then
-		echo online-offline $memory
-		offline_memory_expect_success $memory
+	if [ "$target" -gt 0 ]; then
+		echo "online->offline memory$memory"
+		if offline_memory_expect_success $memory; then
+			target=$(($target - 1))
+		fi
 	fi
 done
+if [ "$target" -gt 0 ]; then
+	retval=1
+	echo -e "\t\t FAILED - unable to offline some memory blocks, device busy?"
+fi
 
 #
 # Online all hot-pluggable memory again
 #
-for memory in `hotplaggable_offline_memory`; do
-	echo offline-online $memory
-	online_memory_expect_success $memory
-done
+hotpluggable_num=`hotpluggable_offline_memory | wc -l`
+echo -e "\t online all hot-pluggable memory in offline state:"
+if [ "$hotpluggable_num" -gt 0 ]; then
+	for memory in `hotpluggable_offline_memory`; do
+		echo "offline->online memory$memory"
+		if ! online_memory_expect_success $memory; then
+			retval=1
+		fi
+	done
+else
+	echo -e "\t\t SKIPPED - no hot-pluggable memory in offline state"
+fi
 
 #
 # Test with memory notifier error injection
@@ -189,15 +234,16 @@ prerequisite_extra()
 
 	if [ ! -d "$DEBUGFS" ]; then
 		echo $msg debugfs is not mounted >&2
-		exit 0
+		exit $((0+$retval))
 	fi
 
 	if [ ! -d $NOTIFIER_ERR_INJECT_DIR ]; then
 		echo $msg memory-notifier-error-inject module is not available >&2
-		exit 0
+		exit $((0+$retval))
 	fi
 }
 
+echo -e "\t Test with memory notifier error injection"
 prerequisite_extra
 
 #
@@ -214,7 +260,7 @@ done
 # Test memory hot-add error handling (offline => online)
 #
 echo $error > $NOTIFIER_ERR_INJECT_DIR/actions/MEM_GOING_ONLINE/error
-for memory in `hotplaggable_offline_memory`; do
+for memory in `hotpluggable_offline_memory`; do
 	online_memory_expect_fail $memory
 done
 
@@ -222,7 +268,7 @@ done
 # Online all hot-pluggable memory
 #
 echo 0 > $NOTIFIER_ERR_INJECT_DIR/actions/MEM_GOING_ONLINE/error
-for memory in `hotplaggable_offline_memory`; do
+for memory in `hotpluggable_offline_memory`; do
 	online_memory_expect_success $memory
 done
 
@@ -236,3 +282,5 @@ done
 
 echo 0 > $NOTIFIER_ERR_INJECT_DIR/actions/MEM_GOING_OFFLINE/error
 /sbin/modprobe -q -r memory-notifier-error-inject
+
+exit $retval


### PR DESCRIPTION
Typo correction for hotpluggable_offline_memory() function.
Check for hot-pluggable memory availability in prerequisite().
Check for precentage range for -r flag.

Fix the memory offline test, the $ratio was used with RANDOM as the
possibility to get it offlined, correct it to become the portion of
available removable memory blocks.
Also ask the tool to try to offline the next available memory block
if the attempt is unsuccessful. It will only fail if all removable
memory blocks are busy.

An nice example:
k@Latitude:~$ sudo ./test.sh
Test scope: 10% hotplug memory
	 online all hot-pluggable memory in offline state:
		SKIPPED - no hot-pluggable memory in offline state
	 offline 10% hot-pluggable memory in online state
	 trying to offline 3 out of 28 memory block(s):
online->offline memory1
online->offline memory10
./test.sh: line 74: echo: write error: Resource temporarily unavailable
offline_memory_expect_success 10: unexpected fail
online->offline memory100
online->offline memory101
	 online all hot-pluggable memory in offline state:
offline->online memory1
offline->online memory100
offline->online memory101
skip extra tests: debugfs is not mounted
k@Latitude:~$ echo $?
0

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>