### PR TITLE
Add support for ELDAT USB EasyWave dongle

### DIFF
--- a/drivers/usb/serial/cp210x.c
+++ b/drivers/usb/serial/cp210x.c
@@ -213,6 +213,8 @@ static const struct usb_device_id id_table[] = {
 	{ USB_DEVICE(0x3195, 0xF280) }, /* Link Instruments MSO-28 */
 	{ USB_DEVICE(0x3195, 0xF281) }, /* Link Instruments MSO-28 */
 	{ USB_DEVICE(0x413C, 0x9500) }, /* DW700 GPS USB interface */
+	{ USB_DEVICE(0x155A, 0x1005) }, /* ELDAT Easywave Transceiver */
+	{ USB_DEVICE(0x155A, 0x1006) }, /* ELDAT USB Transceiver Easywave*/
 	{ } /* Terminating Entry */
 };
 


### PR DESCRIPTION
Add support for the ELDAT USB EasyWave protocol dongle RX09.
You can use the ELDAT devices to build some smart home applications.

more info about this dongle: [http://www.eldat.de/produkte/schnittstellen/rx09e_en.html](url).