### PR TITLE
Make "attempted to kill init" message more clear

### DIFF
--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -575,7 +575,7 @@ static struct task_struct *find_child_reaper(struct task_struct *father)
 
 	write_unlock_irq(&tasklist_lock);
 	if (unlikely(pid_ns == &init_pid_ns)) {
-		panic("Attempted to kill init! exitcode=0x%08x\n",
+		panic("init was killed! exitcode=0x%08x\n",
 			father->signal->group_exit_code ?: father->exit_code);
 	}
 	zap_pid_ns_processes(pid_ns);


### PR DESCRIPTION
The kernel panic occurs as a result of init being successfully killed. I believe this is a clearer message, as it describes that the process has been killed, not merely that there was an attempt. `kill -9 1` is an example of an attempt to kill init, that does not succeed. Thus, I believe changing the message to "init was killed" or similar helps to differentiate between attempts, and successful attempts that cause kernel panics.

The exact message may of course be amended, but I believe it is important that the successful nature of the process kill is noted, in order for better debugging.