### PR TITLE
Update af_irda.c

### DIFF
--- a/net/irda/af_irda.c
+++ b/net/irda/af_irda.c
@@ -2248,6 +2248,8 @@ static int irda_getsockopt(struct socket *sock, int level, int optname,
 			err = -EINVAL;
 			goto out;
 		}
+			
+		memset( &list, 0, sizeof(struct irda_device_list) );
 
 		/* Ask lmp for the current discovery log */
 		discoveries = irlmp_get_discoveries(&list.len, self->mask.word,


### PR DESCRIPTION
Sometimes irda_getsockopt() doesn't initialize all members of list field of irda_device_list struct.  This structure is then copied to
userland.  It leads to leaking of contents of kernel stack memory.  We have to initialize them to zero , or it will allows local users to obtain potentially sensitive information from kernel stack memory by reading a copy of this structure