### PR TITLE
Update atyfb_base.c

### DIFF
--- a/drivers/video/fbdev/aty/atyfb_base.c
+++ b/drivers/video/fbdev/aty/atyfb_base.c
@@ -1857,6 +1857,9 @@ static int atyfb_ioctl(struct fb_info *info, u_int cmd, u_long arg)
 		if (M64_HAS(INTEGRATED)) {
 			struct atyclk clk;
 			union aty_pll *pll = &par->pll;
+			
+			memset( &clk, 0, sizeof(struct atyclk) );
+			
 			u32 dsp_config = pll->ct.dsp_config;
 			u32 dsp_on_off = pll->ct.dsp_on_off;
 			clk.ref_clk_per = par->ref_clk_per;


### PR DESCRIPTION
Structure atyclk is copied to userland with padding bytes after
"vclk_post_div" field unitialized.  It leads to leaking of
contents of kernel stack memory.  We have to initialize them to zero. or it will allows local users to obtain potentially sensitive information from kernel stack memory by reading a copy of this structure