### PR TITLE
Fix missing PCI ID (thanks to CoolStar); Necessary for Lenovo Yoga 720-15 Touchpad

### DIFF
--- a/drivers/mfd/intel-lpss-pci.c
+++ b/drivers/mfd/intel-lpss-pci.c
@@ -221,6 +221,7 @@ static const struct pci_device_id intel_lpss_pci_ids[] = {
 	{ PCI_VDEVICE(INTEL, 0xa12a), (kernel_ulong_t)&spt_info },
 	{ PCI_VDEVICE(INTEL, 0xa160), (kernel_ulong_t)&spt_i2c_info },
 	{ PCI_VDEVICE(INTEL, 0xa161), (kernel_ulong_t)&spt_i2c_info },
+	{ PCI_VDEVICE(INTEL, 0xa162), (kernel_ulong_t)&spt_i2c_info },
 	{ PCI_VDEVICE(INTEL, 0xa166), (kernel_ulong_t)&spt_uart_info },
 	/* KBL-H */
 	{ PCI_VDEVICE(INTEL, 0xa2a7), (kernel_ulong_t)&spt_uart_info },


### PR DESCRIPTION
This patch fixes a missing PCI ID which is necessary for the Lenovo Yoga 720-15 Touchpad to work.
See this bug report on Launchpad:
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1700657

Many thanks to CoolStar, who found this solution!