### PR TITLE
Adding HID_QUIRK_MULTI_INPUT to a BT HID

### DIFF
--- a/net/bluetooth/hidp/core.c
+++ b/net/bluetooth/hidp/core.c
@@ -775,6 +775,11 @@ static int hidp_setup_hid(struct hidp_session *session,
 	hid->version = req->version;
 	hid->country = req->country;
 
+	/* A Bluetooth HID emulator working in a computer usually packs multiple
+	   devices into the single interface. Then add HID_QUIRK_MULTI_INPUT for
+	   maximal compatibility. */
+	hid->quirks = HID_QUIRK_MULTI_INPUT;
+
 	strncpy(hid->name, req->name, sizeof(req->name) - 1);
 
 	snprintf(hid->phys, sizeof(hid->phys), "%pMR",


### PR DESCRIPTION
I'm developing a Bluetooth HID emulator (dubbed "across"; http://www.acrosscenter.com) working in a PC or Mac. Across works well with most of client devices whose OS is Windows, macOS, Windows Phone, Android, iOS. Until now I have been thinking Linux would work well like most of other OS's, but it doesn't.
Across packs keyboard, relative coordinate mice, absolute coordinate mice and absolute coordinate touch device into the single interface. However the absolute coordinate touch device prevents input devices enumerator from loading the whole other devices, and it can work around by adding HID_QUIRK_MULTI_INPUT.