### PR TITLE
fix a bug refer to max_discard is 0

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -2569,7 +2569,7 @@ unsigned int mmc_calc_max_discard(struct mmc_card *card)
 	max_discard = mmc_do_calc_max_discard(card, MMC_ERASE_ARG);
 	if (mmc_can_trim(card)) {
 		max_trim = mmc_do_calc_max_discard(card, MMC_TRIM_ARG);
-		if (max_trim < max_discard)
+		if (max_trim < max_discard || max_discard == 0)
 			max_discard = max_trim;
 	} else if (max_discard < card->erase_size) {
 		max_discard = 0;


### PR DESCRIPTION
typically TRIM cost shorter time than ERASE, so we expect max_trim as max_discard. But when ERASE timeout is too long, it did happened actually rather than theoretically.  A type of Toshiba eMMC's ERASE_TIMEOUT_MULT is too long and controller's max_busy_timeout is relatively small, then max_discard could be 0, even max_trim is available, but max_trim < max_disable can't be true, so we get a result of 0 instead of max_trim.