### PR TITLE
Fixed typo in time.c

### DIFF
--- a/kernel/time/time.c
+++ b/kernel/time/time.c
@@ -181,7 +181,7 @@ int do_sys_settimeofday64(const struct timespec64 *tv, const struct timezone *tz
 		return error;
 
 	if (tz) {
-		/* Verify we're witin the +-15 hrs range */
+		/* Verify we're within the +-15 hrs range */
 		if (tz->tz_minuteswest > 15*60 || tz->tz_minuteswest < -15*60)
 			return -EINVAL;
 


### PR DESCRIPTION
Randomly stumbled upon this:
LINE 184: "Verify we're witin" -> "Verify we're within"