### PR TITLE
Add new FITRIM ioctl for fstrim to trim FAT file system

### DIFF
--- a/fs/fat/fat.h
+++ b/fs/fat/fat.h
@@ -357,6 +357,7 @@ extern int fat_alloc_clusters(struct inode *inode, int *cluster,
 			      int nr_cluster);
 extern int fat_free_clusters(struct inode *inode, int cluster);
 extern int fat_count_free_clusters(struct super_block *sb);
+extern int fat_trim_fs(struct inode *inode, struct fstrim_range *range);
 
 /* fat/file.c */
 extern long fat_generic_ioctl(struct file *filp, unsigned int cmd,


### PR DESCRIPTION
FAT file system lacks the ability to handle FITRIM ioctl, thus we can not use fstrim one FAT filesys.
This change add FITRIM ioctl for fstrim or other tools to leverage.