### PR TITLE
Removed the non working back-quotes from README.md  around make

### DIFF
--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use `makehtmldocs` or
-`makepdfdocs`.  The formatted documentation can also be read online at:
+In order to build the documentation, use <code>makehtmldocs</code> or
+<code>makepdfdocs</code>.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 

--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use ``make htmldocs`` or
-``make pdfdocs``.  The formatted documentation can also be read online at:
+In order to build the documentation, use `makehtmldocs` or
+`makepdfdocs`.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 

--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use `makehtmldocs` or
-`makepdfdocs`.  The formatted documentation can also be read online at:
+In order to build the documentation, use make htmldocs or
+makepdfdocs.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use make htmldocs or
+In order to build the documentation, use `make htmldocs` or
 make pdfdocs.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use `make htmldocs` or
+In order to build the documentation, use make htmldocs or
 make pdfdocs.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/

--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use <code>makehtmldocs</code> or
-<code>makepdfdocs</code>.  The formatted documentation can also be read online at:
+In order to build the documentation, use `makehtmldocs` or
+`makepdfdocs`.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 

--- a/README
+++ b/README
@@ -6,7 +6,7 @@ be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
 In order to build the documentation, use make htmldocs or
-makepdfdocs.  The formatted documentation can also be read online at:
+make pdfdocs.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 


### PR DESCRIPTION
For some reason _make htmldocs_ is not changing into `make htmldocs` in README.md even after trying in multiple ways. So just removed the back quotes which were serving no use.