### PR TITLE
ideapad-laptop: Add E42-80 to no_hw_rfkill list

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -1163,6 +1163,13 @@ static const struct dmi_system_id no_hw_rfkill_list[] = {
 			DMI_MATCH(DMI_PRODUCT_VERSION, "Lenovo YOGA 920-13IKB"),
 		},
 	},
+	{
+		.ident = "Lenovo Zhaoyang E42-80",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_VERSION, "ZHAOYANG E42-80"),
+		},
+	},
 	{}
 };
 


### PR DESCRIPTION
`Lenovo Zhaoyang E42-80` is another Lenovo ideapad model **without a hw rfkill switch**, resulting in wifi always reported as hard blocked.
Add it to the list of models without rfkill switch.