### PR TITLE
Documentation: admin-guide: Adding sysrq-key combination for System Z…

### DIFF
--- a/Documentation/admin-guide/sysrq.rst
+++ b/Documentation/admin-guide/sysrq.rst
@@ -68,6 +68,11 @@ On PowerPC
 	Press :kbd:`ALT - Print Screen` (or :kbd:`F13`) - :kbd:`<command key>`,
         :kbd:`Print Screen` (or :kbd:`F13`) - :kbd:`<command key>` may suffice.
 
+On System Z - Press 'CTRL-O-<command key>' on the hvc0 console.'CTRL-O' means
+              pressing 'O' (not zero) while holding down the 'CTRL' key. For 
+              3270 console or line-mode HMC console: Pass '^-<command key>'
+              Here, '^-' means cap and dash characters.
+
 On other
 	If you know of the key combos for other architectures, please
         let me know so I can add them to this section.

--- a/Documentation/filesystems/proc.txt
+++ b/Documentation/filesystems/proc.txt
@@ -870,6 +870,7 @@ Committed_AS:   100056 kB
 VmallocTotal:   112216 kB
 VmallocUsed:       428 kB
 VmallocChunk:   111088 kB
+HardwareCorrupted:   0 kB
 AnonHugePages:   49152 kB
 ShmemHugePages:      0 kB
 ShmemPmdMapped:      0 kB
@@ -915,6 +916,8 @@ MemAvailable: An estimate of how much memory is available for starting new
        Dirty: Memory which is waiting to get written back to the disk
    Writeback: Memory which is actively being written back to the disk
    AnonPages: Non-file backed pages mapped into userspace page tables
+HardwareCorrupted: The amount of RAM/memory in KB, the kernel identified as 
+              corrupted.
 AnonHugePages: Non-file backed huge pages mapped into userspace page tables
       Mapped: files which have been mmaped, such as libraries
        Shmem: Total memory used by shared memory (shmem) and tmpfs

--- a/Documentation/sysctl/vm.txt
+++ b/Documentation/sysctl/vm.txt
@@ -44,6 +44,7 @@ Currently, these files are in /proc/sys/vm:
 - mmap_rnd_bits
 - mmap_rnd_compat_bits
 - nr_hugepages
+- nr_hugepages_mempolicy
 - nr_overcommit_hugepages
 - nr_trim_pages         (only if CONFIG_MMU=n)
 - numa_zonelist_order
@@ -514,6 +515,15 @@ This value can be changed after boot using the
 nr_hugepages
 
 Change the minimum size of the hugepage pool.
+
+See Documentation/admin-guide/mm/hugetlbpage.rst
+
+==============================================================
+
+nr_hugepages_mempolicy
+
+Change the size of the hugepage pool at run-time on a specific 
+set of NUMA nodes.
 
 See Documentation/admin-guide/mm/hugetlbpage.rst
 


### PR DESCRIPTION
…/S390 arch.

I have made following changes in sysrq.rst

On System Z - Press 'CTRL-O-<command key>' on the hvc0 console.'CTRL-O' means
                        pressing 'O' (not zero) while holding down the 'CTRL' key. For 
                       3270 console or line-mode HMC console: Pass '^-<command key>'
                       Here, '^-' means cap and dash characters.

Signed-off-by: Prashant Dhamdhere <pdhamdhe@redhat.com>




