### PR TITLE
ath9k_htc: increase number of configurable virtual interfaces

### DIFF
--- a/drivers/net/wireless/ath/ath9k/htc.h
+++ b/drivers/net/wireless/ath/ath9k/htc.h
@@ -197,8 +197,8 @@ struct ath9k_htc_target_rx_stats {
 	__be32 host_done;
 } __packed;
 
-#define ATH9K_HTC_MAX_VIF 2
-#define ATH9K_HTC_MAX_BCN_VIF 2
+#define ATH9K_HTC_MAX_VIF 8
+#define ATH9K_HTC_MAX_BCN_VIF 8
 
 #define INC_VIF(_priv, _type) do {		\
 		switch (_type) {		\

--- a/drivers/net/wireless/ath/ath9k/htc_drv_init.c
+++ b/drivers/net/wireless/ath/ath9k/htc_drv_init.c
@@ -697,9 +697,9 @@ err_hw:
 }
 
 static const struct ieee80211_iface_limit if_limits[] = {
-	{ .max = 2,	.types = BIT(NL80211_IFTYPE_STATION) |
+	{ .max = 8,	.types = BIT(NL80211_IFTYPE_STATION) |
 				 BIT(NL80211_IFTYPE_P2P_CLIENT) },
-	{ .max = 2,	.types = BIT(NL80211_IFTYPE_AP) |
+	{ .max = 8,	.types = BIT(NL80211_IFTYPE_AP) |
 #ifdef CONFIG_MAC80211_MESH
 				 BIT(NL80211_IFTYPE_MESH_POINT) |
 #endif
@@ -709,7 +709,7 @@ static const struct ieee80211_iface_limit if_limits[] = {
 static const struct ieee80211_iface_combination if_comb = {
 	.limits = if_limits,
 	.n_limits = ARRAY_SIZE(if_limits),
-	.max_interfaces = 2,
+	.max_interfaces = 8,
 	.num_different_channels = 1,
 };
 


### PR DESCRIPTION
Testing with AR9271 USB device I was able to start 8 VAPs, but one client device could connect only if 7 VAPs were configured. This might need more work to make the feature fully usable, but even at present situation it enables functionality that was previously disabled.
Updated ath9k_htc firmware is required too, PR already opened: https://github.com/qca/open-ath9k-htc-firmware/pull/149

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>