### PR TITLE
pktcdvd.c: Fix wrong return code when alloc_disk() fails.

### DIFF
--- a/drivers/block/pktcdvd.c
+++ b/drivers/block/pktcdvd.c
@@ -2716,8 +2716,10 @@ static int pkt_setup_dev(dev_t dev, dev_t* pkt_dev)
 	pd->write_congestion_off = write_congestion_off;
 
 	disk = alloc_disk(1);
-	if (!disk)
+	if (!disk) {
+		ret = -ENOMEM;
 		goto out_mem;
+	}
 	pd->disk = disk;
 	disk->major = pktdev_major;
 	disk->first_minor = idx;


### PR DESCRIPTION
Function pkt_setup_dev() defined in drivers/block/pktcdvd.c calls alloc_disk(). However, it forgets to set the error return code when alloc_disk() fails. Instead, when alloc_disk() fails, it simply jumps to label 'out_mem' leaving the variable ret unchanged.