### PR TITLE
conntrack.c: Add missing return value check to prevent nptr dereference.

### DIFF
--- a/net/openvswitch/conntrack.c
+++ b/net/openvswitch/conntrack.c
@@ -2132,6 +2132,10 @@ static int ovs_ct_limit_cmd_get(struct sk_buff *skb, struct genl_info *info)
 		return PTR_ERR(reply);
 
 	nla_reply = nla_nest_start(reply, OVS_CT_LIMIT_ATTR_ZONE_LIMIT);
+	if (!nla_reply) {
+		err = -ENOMEM;
+		goto exit_err;
+	}
 
 	if (a[OVS_CT_LIMIT_ATTR_ZONE_LIMIT]) {
 		err = ovs_ct_limit_get_zone_limit(


### PR DESCRIPTION
Function ovs_ct_limit_cmd_get() defined in net/openvswitch/conntrack.c may cause a null pointer dereference as it calls nla_nest_start which may return NULL. The returned value is used in function nla_nest_end() later where the pointer is dereferenced.