### PR TITLE
ahci.c -- add Marvell 88SE6141 SATA controller

### DIFF
--- a/drivers/ata/ahci.c
+++ b/drivers/ata/ahci.c
@@ -526,6 +526,7 @@ static const struct pci_device_id ahci_pci_tbl[] = {
 
 	/* Marvell */
 	{ PCI_VDEVICE(MARVELL, 0x6145), board_ahci_mv },	/* 6145 */
+	{ PCI_VDEVICE(MARVELL, 0x6141), board_ahci_mv },	/* 88se6141*/ 
 	{ PCI_VDEVICE(MARVELL, 0x6121), board_ahci_mv },	/* 6121 */
 	{ PCI_DEVICE(PCI_VENDOR_ID_MARVELL_EXT, 0x9123),
 	  .class = PCI_CLASS_STORAGE_SATA_AHCI,


### PR DESCRIPTION
Added a line to support Marvell 88SE6141 SATA controller. According to https://forums.gentoo.org/viewtopic-t-581669-start-0.html this is what the manufacturer's driver did (i.e. patch the kernel with this line).
Adding this to the main ahci.c file would provide out-of-the box support for Marvell 88SE6141. 