### PR TITLE
elan_i2c_core.c -- add ACPI ID for Lenovo Ideapad 330-15IGM

### DIFF
--- a/drivers/input/mouse/elan_i2c_core.c
+++ b/drivers/input/mouse/elan_i2c_core.c
@@ -1350,6 +1350,7 @@ static const struct acpi_device_id elan_acpi_id[] = {
 	{ "ELAN061D", 0 },
 	{ "ELAN0622", 0 },
 	{ "ELAN1000", 0 },
+	{ "ELAN061E", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(acpi, elan_acpi_id);


### PR DESCRIPTION
Got this error in dmesg: i2c_hid i2c-ELAN061E:00: i2c-ELAN061E:00 supply vdd not found, using dummy regulator