### PR TITLE
spi: dw: fix potential variable assignment error

### DIFF
--- a/drivers/spi/spi-dw.c
+++ b/drivers/spi/spi-dw.c
@@ -317,7 +317,8 @@ static int dw_spi_transfer_one(struct spi_controller *master,
 	/* Default SPI mode is SCPOL = 0, SCPH = 0 */
 	cr0 = (transfer->bits_per_word - 1)
 		| (chip->type << SPI_FRF_OFFSET)
-		| (spi->mode << SPI_MODE_OFFSET)
+		| ((((spi->mode & SPI_CPOL)?1:0) << SPI_SCOL_OFFSET) |
+			(((spi->mode & SPI_CPHA)?1:0) << SPI_SCPH_OFFSET))
 		| (chip->tmode << SPI_TMOD_OFFSET);
 
 	/*


### PR DESCRIPTION
spi::mode is defined by framework for several SPI capabilities, such as polarity, phase, bit-endian, wire number.
Directly use this variable for setting controller's polarity and phase is inappropriate.
Since SPI framework has its definition,  fetch required bit in spi::mode and set to register.