### PR TITLE
add ACPI ID for Lenovo IdeaPad 330-15ARR

### DIFF
--- a/drivers/input/mouse/elan_i2c_core.c
+++ b/drivers/input/mouse/elan_i2c_core.c
@@ -1348,6 +1348,7 @@ static const struct acpi_device_id elan_acpi_id[] = {
 	{ "ELAN0618", 0 },
 	{ "ELAN061C", 0 },
 	{ "ELAN061D", 0 },
+	{ "ELAN061E", 0 },
 	{ "ELAN0622", 0 },
 	{ "ELAN1000", 0 },
 	{ }


### PR DESCRIPTION
Add ELAN061E to the ACPI table to support Elan touchpad found in Lenovo IdeaPad 330-15ARR.