### PR TITLE
sched/debug: Change /proc/sched_debug from 0444 to 0400

### DIFF
--- a/kernel/sched/debug.c
+++ b/kernel/sched/debug.c
@@ -824,7 +824,7 @@ static const struct seq_operations sched_debug_sops = {
 
 static int __init init_sched_debug_procfs(void)
 {
-	if (!proc_create_seq("sched_debug", 0444, NULL, &sched_debug_sops))
+	if (!proc_create_seq("sched_debug", 0400, NULL, &sched_debug_sops))
 		return -ENOMEM;
 	return 0;
 }


### PR DESCRIPTION
Just like the upstream commit 8e7df2b, there's not enough reasons to read this file as non-root.
The old CVE-2014-1738 could have been prevented by this.