### PR TITLE
Add dynfunc1() syscall

### DIFF
--- a/arch/x86/entry/syscalls/syscall_32.tbl
+++ b/arch/x86/entry/syscalls/syscall_32.tbl
@@ -398,3 +398,4 @@
 384	i386	arch_prctl		sys_arch_prctl			__ia32_compat_sys_arch_prctl
 385	i386	io_pgetevents		sys_io_pgetevents		__ia32_compat_sys_io_pgetevents
 386	i386	rseq			sys_rseq			__ia32_sys_rseq
+387	i386	dynfunc1		sys_dynfunc1			__ia32_sys_dynfunc1

--- a/arch/x86/entry/syscalls/syscall_64.tbl
+++ b/arch/x86/entry/syscalls/syscall_64.tbl
@@ -343,6 +343,7 @@
 332	common	statx			__x64_sys_statx
 333	common	io_pgetevents		__x64_sys_io_pgetevents
 334	common	rseq			__x64_sys_rseq
+335	common	dynfunc1		__x64_sys_dynfunc1
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -2639,3 +2639,25 @@ COMPAT_SYSCALL_DEFINE1(sysinfo, struct compat_sysinfo __user *, info)
 	return 0;
 }
 #endif /* CONFIG_COMPAT */
+
+/* Add dynamical system call */
+struct dynfunc1_st {
+    long (*fn)(unsigned long p);
+} dynfunc1 = {
+    NULL
+};
+
+EXPORT_SYMBOL(dynfunc1);
+
+SYSCALL_DEFINE1(dynfunc1, unsigned long, p)
+{
+    struct dynfunc1_st *s = (struct dynfunc1_st *)&dynfunc1;
+
+    pr_info("Entering dynfunc with p = %ld at jiffies=%ld\n",
+            p, jiffies);
+
+    if (!s || !s->fn)
+        return -ENOSYS;
+
+    return s->fn(p);
+}


### PR DESCRIPTION
dynfunc1() is a system call that supports adding function in kernel module to process parameter passed to dynfunc1().