### PR TITLE
Add an interface for CFS bandwidth

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -6728,7 +6728,7 @@ long tg_get_cfs_percent(struct task_group *tg)
 }
 
 static s64 cpu_cfs_quota_read_s64(struct cgroup_subsys_state *css,
-				  struct cftype *cft)
+				   struct cftype *cft)
 {
 	return tg_get_cfs_quota(css_tg(css));
 }
@@ -6746,19 +6746,19 @@ static u64 cpu_cfs_period_read_u64(struct cgroup_subsys_state *css,
 }
 
 static int cpu_cfs_period_write_u64(struct cgroup_subsys_state *css,
-				    struct cftype *cftype, u64 cfs_period_us)
+				   struct cftype *cftype, u64 cfs_period_us)
 {
 	return tg_set_cfs_period(css_tg(css), cfs_period_us);
 }
 
 static s64 cpu_cfs_percent_read_u64(struct cgroup_subsys_state *css,
-				    struct cftype *cft)
+				   struct cftype *cft)
 {
 	return tg_get_cfs_percent(css_tg(css));
 }
 
 static int cpu_cfs_percent_write_u64(struct cgroup_subsys_state *css,
-				    struct cftype *cftype, u64 cfs_percent)
+				   struct cftype *cftype, u64 cfs_percent)
 {
 	return tg_set_cfs_percent(css_tg(css), cfs_percent);
 }

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -6751,13 +6751,13 @@ static int cpu_cfs_period_write_u64(struct cgroup_subsys_state *css,
 	return tg_set_cfs_period(css_tg(css), cfs_period_us);
 }
 
-static s64 cpu_cfs_bandwidth_read_u64(struct cgroup_subsys_state *css,
+static s64 cpu_cfs_percent_read_u64(struct cgroup_subsys_state *css,
 				    struct cftype *cft)
 {
 	return tg_get_cfs_percent(css_tg(css));
 }
 
-static int cpu_cfs_bandwidth_write_u64(struct cgroup_subsys_state *css,
+static int cpu_cfs_percent_write_u64(struct cgroup_subsys_state *css,
 				    struct cftype *cftype, u64 cfs_percent)
 {
 	return tg_set_cfs_percent(css_tg(css), cfs_percent);
@@ -6921,8 +6921,8 @@ static struct cftype cpu_legacy_files[] = {
 	},
 	{
 		.name = "cfs_percent",
-		.read_s64 = cpu_cfs_bandwidth_read_u64,
-		.write_u64 = cpu_cfs_bandwidth_write_u64,
+		.read_s64 = cpu_cfs_percent_read_u64,
+		.write_u64 = cpu_cfs_percent_write_u64,
 	}
 #endif
 #ifdef CONFIG_RT_GROUP_SCHED


### PR DESCRIPTION
I added an interface which is more intuitive and takes less write/read systemcalls. 

I think that most people don't really care period and quota of CFS Bandwidth, They just use it like "I will allow this process to use 50% of single core" in most cases. But I know that we still need to care period and quota in some cases.

Please consider for merging this if you like, thanks.