### PR TITLE
drivers/gpio PCA9555 - epoll_wait(2) misses first irq after setting an irq mask...

### DIFF
--- a/drivers/gpio/gpio-pca953x.c
+++ b/drivers/gpio/gpio-pca953x.c
@@ -716,12 +716,15 @@ static bool pca953x_irq_pending(struct pca953x_chip *chip, u8 *pending)
 		trigger[i] = (cur_stat[i] ^ old_stat[i]) & chip->irq_mask[i];
 		if (trigger[i])
 			trigger_seen = true;
+
+    /* We want the current status recorded in the chip->irq stat regardless the
+     * chip->irq_mask setting in order to have a change detected when the interrupt
+     * mask gets changed i.e. echo "both" > /sys/class/gpioXYZ/edge */
+    chip->irq_stat[i] = cur_stat[i];
 	}
 
 	if (!trigger_seen)
 		return false;
-
-	memcpy(chip->irq_stat, cur_stat, NBANK(chip));
 
 	for (i = 0; i < NBANK(chip); i++) {
 		pending[i] = (old_stat[i] & chip->irq_trig_fall[i]) |


### PR DESCRIPTION
When ones changes the state of any input pins of a PCA9555 chip before setting up the IRQ mask through i.e. SysFS e.g.

echo "both" > /sys/class/gpio/gpioXYZ/edge the epoll_wait shall not exit on the subsequent change of the GPIO state.
The reason behind it is that the IRQ status is not being saved when the IRQ is masked.