### PR TITLE
Ideapad S205 has a hardware switch but den ACPI driver reads the hard…

### DIFF
--- a/drivers/platform/x86/ideapad-laptop.c
+++ b/drivers/platform/x86/ideapad-laptop.c
@@ -986,6 +986,13 @@ static void ideapad_wmi_notify(u32 value, void *context)
  */
 static const struct dmi_system_id no_hw_rfkill_list[] = {
 	{
+		.ident = "Lenovo Ideapad S205",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_VERSION, "Ideapad S205"),
+		},
+	},	
+	{
 		.ident = "Lenovo RESCUER R720-15IKBN",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),


### PR DESCRIPTION
…ware state wrong, so the wifi is hard blocked and not working.

Instead of adding hundreds of exceptions of lenovo laptops, why not adding a switch for loading the module with wifi hardware state unblocked or something like this,