### PR TITLE
[Documentation Fix] LSM Hooks

### DIFF
--- a/include/linux/lsm_hooks.h
+++ b/include/linux/lsm_hooks.h
@@ -41,7 +41,7 @@
  *	transitions between security domains).
  *	This hook may be called multiple times during a single execve, e.g. for
  *	interpreters.  The hook can tell whether it has already been called by
- *	checking to see if @bprm->security is non-NULL.  If so, then the hook
+ *	checking to see if @bprm->cred->security is non-NULL.  If so, then the hook
  *	may decide either to retain the security information saved earlier or
  *	to replace it.  The hook must set @bprm->secureexec to 1 if a "secure
  *	exec" has happened as a result of this hook call.  The flag is used to

--- a/include/linux/lsm_hooks.h
+++ b/include/linux/lsm_hooks.h
@@ -35,7 +35,7 @@
  * Security hooks for program execution operations.
  *
  * @bprm_set_creds:
- *	Save security information in the bprm->security field, typically based
+ *	Save security information in the bprm->cred->security field, typically based
  *	on information about the bprm->file, for later use by the apply_creds
  *	hook.  This hook may also optionally check permissions (e.g. for
  *	transitions between security domains).
@@ -52,8 +52,8 @@
  *	Return 0 if the hook is successful and permission is granted.
  * @bprm_check_security:
  *	This hook mediates the point when a search for a binary handler will
- *	begin.  It allows a check the @bprm->security value which is set in the
- *	preceding set_creds call.  The primary difference from set_creds is
+ *	begin.  It allows a check the @bprm->cred->security value which is set in
+ *  the preceding set_creds call.  The primary difference from set_creds is
  *	that the argv list and envp list are reliably available in @bprm.  This
  *	hook may be called multiple times during a single execve; and in each
  *	pass set_creds is called first.

--- a/include/linux/lsm_hooks.h
+++ b/include/linux/lsm_hooks.h
@@ -53,7 +53,7 @@
  * @bprm_check_security:
  *	This hook mediates the point when a search for a binary handler will
  *	begin.  It allows a check the @bprm->cred->security value which is set in
- *  the preceding set_creds call.  The primary difference from set_creds is
+ *	the preceding set_creds call.  The primary difference from set_creds is
  *	that the argv list and envp list are reliably available in @bprm.  This
  *	hook may be called multiple times during a single execve; and in each
  *	pass set_creds is called first.


### PR DESCRIPTION
**Purpose**
This PR aims to fix the documentation of `bprm_set_creds` and `bprm_check_security` hooks.

**Issue**
Earlier the docstrings erroneously used `@bprm->security`. However, the `struct linux_binprm` does not have a `security` field. It has a `cred` field which in turn has the desired `security` `void *`. Hence the correct

**Fix**
The correct usage should be `@bprm->cred->security`. Hence I replaced all occurrences of `@bprm->security` with the correct one.

[SELinux](https://github.com/torvalds/linux/blob/master/security/selinux/hooks.c#L2323) too uses `bprm->cred->security` in their codebase.