### PR TITLE
ACPICA: Fix compilation with bare-metal toolchian

### DIFF
--- a/include/acpi/platform/acenv.h
+++ b/include/acpi/platform/acenv.h
@@ -148,7 +148,7 @@
 
 #endif
 
-#if defined(_LINUX) || defined(__linux__)
+#if defined(_LINUX) || defined(__KERNEL__) || defined(__linux__)
 #include <acpi/platform/aclinux.h>
 
 #elif defined(_APPLE) || defined(__APPLE__)

--- a/include/acpi/platform/acenvex.h
+++ b/include/acpi/platform/acenvex.h
@@ -19,7 +19,7 @@
  *
  *****************************************************************************/
 
-#if defined(_LINUX) || defined(__linux__)
+#if defined(_LINUX) || defined(__KERNEL__) || defined(__linux__)
 #include <acpi/platform/aclinuxex.h>
 
 #elif defined(__DragonFly__)


### PR DESCRIPTION
An ifdef expects to be compiled with full-fledged Linux toolchain,
but it's common to compile kernel with just bare-metal toolchain
which doesn't define __linux__. So, also add __KERNEL__ check.

Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>