### PR TITLE
dt-bindings: net: dsa: Fix documentation for qca8k

### DIFF
--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
@@ -77,7 +77,7 @@ for the external mdio-bus configuration:
 					ethernet = <&gmac1>;
 					phy-mode = "rgmii";
 					fixed-link {
-						speed = 1000;
+						speed = <1000>;
 						full-duplex;
 					};
 				};
@@ -135,7 +135,7 @@ for the internal master mdio-bus configuration:
 					ethernet = <&gmac1>;
 					phy-mode = "rgmii";
 					fixed-link {
-						speed = 1000;
+						speed = <1000>;
 						full-duplex;
 					};
 				};


### PR DESCRIPTION
Add missing Less than an Greater than signs in the examples.