### PR TITLE
Improved doc-comment in stackleak_plugin.c

### DIFF
--- a/scripts/gcc-plugins/stackleak_plugin.c
+++ b/scripts/gcc-plugins/stackleak_plugin.c
@@ -144,8 +144,6 @@ static unsigned int stackleak_instrument_execute(void)
 	 *
 	 * Case in point: native_save_fl on amd64 when optimized for size
 	 * clobbers rdx if it were instrumented here.
-	 *
-	 * TODO: any more special cases?
 	 */
 	if (is_leaf &&
 	    !TREE_PUBLIC(current_function_decl) &&


### PR DESCRIPTION
Cleaned documentation comment up. I removed the "TODO" because it was very old.