### PR TITLE
Update core-cdev.c

### DIFF
--- a/drivers/firewire/core-cdev.c
+++ b/drivers/firewire/core-cdev.c
@@ -376,7 +376,7 @@ static void queue_bus_reset_event(struct client *client)
 {
 	struct bus_reset_event *e;
 
-	e = kzalloc(sizeof(*e), GFP_KERNEL);
+	e = kzalloc(sizeof(*e), GFP_KERNEL | GFP_DMA);
 	if (e == NULL)
 		return;
 
@@ -587,7 +587,7 @@ static int init_request(struct client *client,
 	    request->length < 4)
 		return -EINVAL;
 
-	e = kmalloc(sizeof(*e) + request->length, GFP_KERNEL);
+	e = kmalloc(sizeof(*e) + request->length, GFP_KERNEL | GFP_DMA);
 	if (e == NULL)
 		return -ENOMEM;
 
@@ -765,7 +765,7 @@ static int ioctl_allocate(struct client *client, union ioctl_arg *arg)
 	struct fw_address_region region;
 	int ret;
 
-	r = kmalloc(sizeof(*r), GFP_KERNEL);
+	r = kmalloc(sizeof(*r), GFP_KERNEL | GFP_DMA);
 	if (r == NULL)
 		return -ENOMEM;
 
@@ -869,7 +869,7 @@ static int ioctl_add_descriptor(struct client *client, union ioctl_arg *arg)
 	if (a->length > 256)
 		return -EINVAL;
 
-	r = kmalloc(sizeof(*r) + a->length * 4, GFP_KERNEL);
+	r = kmalloc(sizeof(*r) + a->length * 4, GFP_KERNEL | GFP_DMA);
 	if (r == NULL)
 		return -ENOMEM;
 
@@ -1513,7 +1513,7 @@ static int ioctl_send_phy_packet(struct client *client, union ioctl_arg *arg)
 	if (!client->device->is_local)
 		return -ENOSYS;
 
-	e = kzalloc(sizeof(*e) + 4, GFP_KERNEL);
+	e = kzalloc(sizeof(*e) + 4, GFP_KERNEL | GFP_DMA);
 	if (e == NULL)
 		return -ENOMEM;
 


### PR DESCRIPTION
When dynamically allocating DMA-capable memory in PowerPC, the kernel must explicitly specify the GFP_DMA flag. 

Tested with T2080 Processor communicating over PCIe to two TI 1394 OHCI links.