### PR TITLE
Update j1939.rst

### DIFF
--- a/Documentation/networking/j1939.rst
+++ b/Documentation/networking/j1939.rst
@@ -339,7 +339,7 @@ To claim an address following code example can be used:
 			.pgn = J1939_PGN_ADDRESS_CLAIMED,
 			.pgn_mask = J1939_PGN_PDU1_MAX,
 		}, {
-			.pgn = J1939_PGN_ADDRESS_REQUEST,
+			.pgn = J1939_PGN_REQUEST,
 			.pgn_mask = J1939_PGN_PDU1_MAX,
 		}, {
 			.pgn = J1939_PGN_ADDRESS_COMMANDED,


### PR DESCRIPTION
[networking/j1939.rst](https://github.com/torvalds/linux/blob/master/Documentation/networking/j1939.rst)
 referes to J1939_PGN_ADDRESS_REQUEST, however "j1939.h" defines only:
#define J1939_PGN_REQUEST 0x0ea00

There was once a patch changing the define "J1939_PGN_REQUEST" to "J1939_PGN_ADDRESS_REQUEST". However this patch had been rejected. Still the documentation [networking/j1939.rst](https://github.com/torvalds/linux/blob/master/Documentation/networking/j1939.rst) had been written as if this patch had been applied: 
[Link to patch](https://marc.info/?l=linux-can&m=155491812521734&w=2)

I have created here an issue for discussion:
https://github.com/linux-can/can-utils/issues/174