### PR TITLE
gen_initramfs_list.sh is a bash script that isn't posix compliant.

### DIFF
--- a/usr/Makefile
+++ b/usr/Makefile
@@ -27,7 +27,7 @@ $(obj)/initramfs_data.o: $(obj)/$(datafile_y) FORCE
 # Generate the initramfs cpio archive
 
 hostprogs-y := gen_init_cpio
-initramfs   := $(CONFIG_SHELL) $(srctree)/$(src)/gen_initramfs_list.sh
+initramfs   := $(BASH) $(srctree)/$(src)/gen_initramfs_list.sh
 ramfs-input := $(if $(filter-out "",$(CONFIG_INITRAMFS_SOURCE)), \
 			$(shell echo $(CONFIG_INITRAMFS_SOURCE)),-d)
 ramfs-args  := \


### PR DESCRIPTION
This ensures we call bash instead of sh which could be dash or any other
shell that is not compatible with the script.

Signed-off-by: Jory Pratt <anarchy@gentoo.org>