### PR TITLE
Included missing <strings.h>

### DIFF
--- a/scripts/kconfig/confdata.c
+++ b/scripts/kconfig/confdata.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/scripts/kconfig/confdata.c
+++ b/scripts/kconfig/confdata.c
@@ -72,7 +72,8 @@ static bool is_same(const char *file1, const char *file2)
 	if (map2 == MAP_FAILED)
 		goto close2;
 
-	if (bcmp(map1, map2, st1.st_size))
+// using android, bcmp does not works, but memcmp yes:
+	if (memcmp(map1, map2, st1.st_size))
 		goto close2;
 
 	ret = true;


### PR DESCRIPTION
``bcmd()`` is a function from ``<strings.h>`` (with s) that are not included in the file, so Mmy compiler throws an error:

```sh
$ make -j 8
HOSTCC  scripts/kconfig/confdata.o
scripts/kconfig/confdata.c:75:6: warning: implicitly declaring library function 'bcmp'
      with type 'int (const void *, const void *, unsigned int)'
      [-Wimplicit-function-declaration]
        if (bcmp(map1, map2, st1.st_size))
            ^
scripts/kconfig/confdata.c:75:6: note: include the header <strings.h> or explicitly
      provide a declaration for 'bcmp'
1 warning generated.
  HOSTLD  scripts/kconfig/conf
/data/data/com.termux/files/usr/bin/arm-linux-androideabi-ld: scripts/kconfig/confdata.o: in function `conf_write':                                                               confdata.c:(.text+0x1484): undefined reference to `bcmp'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [scripts/Makefile.host:116: scripts/kconfig/conf] Error 1
make[1]: *** [Makefile:567: syncconfig] Error 2
make: *** [Makefile:678: include/config/auto.conf.cmd] Error 2
```
im following [that tutorial](https://gist.github.com/EduApps-CDG/733e29c28dd53e91128d384c2e879397) that says how to compile the Kernel with a Android, but thr error is not on the tutorial, but on compile.