### PR TITLE
Fix alignment of value in /proc/$pid/smaps

### DIFF
--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -810,7 +810,7 @@ static void __show_smap(struct seq_file *m, const struct mem_size_stats *mss,
 	SEQ_PUT_DEC(" kB\nLazyFree:       ", mss->lazyfree);
 	SEQ_PUT_DEC(" kB\nAnonHugePages:  ", mss->anonymous_thp);
 	SEQ_PUT_DEC(" kB\nShmemPmdMapped: ", mss->shmem_thp);
-	SEQ_PUT_DEC(" kB\nFilePmdMapped: ", mss->file_thp);
+	SEQ_PUT_DEC(" kB\nFilePmdMapped:  ", mss->file_thp);
 	SEQ_PUT_DEC(" kB\nShared_Hugetlb: ", mss->shared_hugetlb);
 	seq_put_decimal_ull_width(m, " kB\nPrivate_Hugetlb: ",
 				  mss->private_hugetlb >> 10, 7);
@@ -840,7 +840,7 @@ static int show_smap(struct seq_file *m, void *v)
 
 	__show_smap(m, &mss, false);
 
-	seq_printf(m, "THPeligible:		%d\n",
+	seq_printf(m, "THPeligible:           %d\n",
 		   transparent_hugepage_enabled(vma));
 
 	if (arch_pkeys_enabled())


### PR DESCRIPTION
The `/proc/$pid/smaps` output has an alignment issue for the field `FilePmdMapped` and `THPeligible`.

This increases the alignment of `FilePmdMapped` by 1 space, and converts the alignment of `THPeligible` to use spaces instead of tabs, to be consistent with the other fields.