### PR TITLE
Improve readability of socket err

### DIFF
--- a/tools/testing/selftests/net/socket.c
+++ b/tools/testing/selftests/net/socket.c
@@ -72,7 +72,7 @@ static int run_tests(void)
 				strerror_r(errno, err_string1, ERR_STRING_SZ);
 
 				fprintf(stderr, "socket(%d, %d, %d) expected "
-					"success got err (%s)\n",
+					"success but got err (%s)\n",
 					s->domain, s->type, s->protocol,
 					err_string1);
 


### PR DESCRIPTION
socket {} expected success "but" got err {}