### PR TITLE
Fix typo in cntl_msg_types

### DIFF
--- a/include/uapi/linux/netfilter/nfnetlink_conntrack.h
+++ b/include/uapi/linux/netfilter/nfnetlink_conntrack.h
@@ -3,7 +3,7 @@
 #define _IPCONNTRACK_NETLINK_H
 #include <linux/netfilter/nfnetlink.h>
 
-enum cntl_msg_types {
+enum ctnl_msg_types {
 	IPCTNL_MSG_CT_NEW,
 	IPCTNL_MSG_CT_GET,
 	IPCTNL_MSG_CT_DELETE,


### PR DESCRIPTION
I think this should be a typo (`cntl_msg_types` vs `ctnl_msg_types`), but I'm not sure whether we can change the type name in uAPI headers (which seems to be not used anywhere).

I tried to search `cntl_msg_types` on https://bugzilla.kernel.org but got nothing.
I've also tried to search this typo by search engine but only found one repo indicating this typo https://github.com/ti-mo/conntrack/blob/7ac9c2a61f2dc6d042b0d1bd53881ca84f09aa4e/enum.go#L17

So I came here to see how we should deal with this kind of typos.