### PR TITLE
Input: xpad - add support for Gamesir T4 Cyclone

### DIFF
--- a/drivers/input/joystick/xpad.c
+++ b/drivers/input/joystick/xpad.c
@@ -379,6 +379,7 @@ static const struct xpad_device {
 	{ 0x31e3, 0x1310, "Wooting 60HE (ARM)", 0, XTYPE_XBOX360 },
 	{ 0x3285, 0x0607, "Nacon GC-100", 0, XTYPE_XBOX360 },
 	{ 0x3537, 0x1004, "GameSir T4 Kaleid", 0, XTYPE_XBOX360 },
+	{ 0x3537, 0x1014, "GameSir T4 Cyclone", 0, XTYPE_XBOX360 },
 	{ 0x3767, 0x0101, "Fanatec Speedster 3 Forceshock Wheel", 0, XTYPE_XBOX },
 	{ 0xffff, 0xffff, "Chinese-made Xbox Controller", 0, XTYPE_XBOX },
 	{ 0x0000, 0x0000, "Generic X-Box pad", 0, XTYPE_UNKNOWN }


### PR DESCRIPTION
Add Gamesir T4 Cyclone to the list of supported devices.

When I connect under Linux it only works in DInput, when I connect it under Windows it is able to switch to XInput.
If I then reboot into Linux, the gamepad stays in XInput mode.

lsusb in DInput: 3537:1006 GameSir GameSir-Cyclone
lsusb in XInput: 3537:1014 Microsoft Xbox 360 for Windows Controller

