### PR TITLE
Update digsig_asymmetric.c

### DIFF
--- a/security/integrity/digsig_asymmetric.c
+++ b/security/integrity/digsig_asymmetric.c
@@ -24,7 +24,7 @@ static struct key *request_asymmetric_key(struct key *keyring, uint32_t keyid)
 	struct key *key;
 	char name[12];
 
-	sprintf(name, "id:%08x", keyid);
+	snprintf(name, sizeof(name), "id:%08x", keyid);
 
 	pr_debug("key search: \"%s\"\n", name);
 


### PR DESCRIPTION
Using snprintf instead of sprintf can help prevent buffer overflows