### PR TITLE
Optimization of `remote_function`

### DIFF
--- a/kernel/events/core.c
+++ b/kernel/events/core.c
@@ -74,23 +74,13 @@ static void remote_function(void *data)
 	struct remote_function_call *tfc = data;
 	struct task_struct *p = tfc->p;
 
-	if (p) {
-		/* -EAGAIN */
-		if (task_cpu(p) != smp_processor_id())
-			return;
-
-		/*
-		 * Now that we're on right CPU with IRQs disabled, we can test
-		 * if we hit the right task without races.
-		 */
-
+	if (p && task_cpu(p) == smp_processor_id() && p == current) {
+		tfc->ret = tfc->func(tfc->info);
+	} else {
 		tfc->ret = -ESRCH; /* No such (running) process */
-		if (p != current)
-			return;
 	}
-
-	tfc->ret = tfc->func(tfc->info);
 }
+
 
 /**
  * task_function_call - call a function on the cpu on which a task runs


### PR DESCRIPTION
## Description
I have made some changes to the `remote_function` to improve its readability and maintainability. Specifically, I have removed early returns and grouped the conditions into a single `if`.

## Proposed Changes
Here is the optimized code:

```c
static void remote_function(void *data)
{
	struct remote_function_call *tfc = data;
	struct task_struct *p = tfc->p;

	if (p && task_cpu(p) == smp_processor_id() && p == current) {
		tfc->ret = tfc->func(tfc->info);
	} else {
		tfc->ret = -ESRCH; /* No such (running) process */
	}
}
```


These changes make the code more readable and concise, facilitating future maintenance.

I hope these changes are beneficial and look forward to your feedback.