### PR TITLE
Fixes vmware failure to build modules on Fedora 40

### DIFF
--- a/arch/x86/include/asm/timex.h
+++ b/arch/x86/include/asm/timex.h
@@ -2,6 +2,8 @@
 #ifndef _ASM_X86_TIMEX_H
 #define _ASM_X86_TIMEX_H
 
+extern unsigned long random_get_entropy_fallback(void);
+
 #include <asm/processor.h>
 #include <asm/tsc.h>
 

--- a/arch/x86/include/asm/timex.h
+++ b/arch/x86/include/asm/timex.h
@@ -2,10 +2,10 @@
 #ifndef _ASM_X86_TIMEX_H
 #define _ASM_X86_TIMEX_H
 
-extern unsigned long random_get_entropy_fallback(void);
-
 #include <asm/processor.h>
 #include <asm/tsc.h>
+
+extern unsigned long random_get_entropy_fallback(void);
 
 static inline unsigned long random_get_entropy(void)
 {


### PR DESCRIPTION
on Fedora 40 and kernel 6.8.8-300.fc40.x86_64 VMWare failes to build modules,  complaining of missing function

this is a fix for this issue that results in vmmon and vmnet kernel modules fails to build I hope its useful
Cheers