### PR TITLE
Fixes vmware failure to build modules

### DIFF
--- a/arch/x86/include/asm/timex.h
+++ b/arch/x86/include/asm/timex.h
@@ -6,11 +6,10 @@
 #include <asm/tsc.h>
 
 /*
-Fixes failure of vmware installer to build vmmon and vmnet kernel modules
-as random_get_entropy_fallback() is not found in the included files from this
-file.
+* Fix for vmware installer failure to build vmmon and vmnet kernel modules
+* as random_get_entropy_fallback() is not found in this unit.
 */
-extern unsigned long random_get_entropy_fallback(void);
+unsigned long random_get_entropy_fallback(void);
 
 static inline unsigned long random_get_entropy(void)
 {

--- a/arch/x86/include/asm/timex.h
+++ b/arch/x86/include/asm/timex.h
@@ -9,7 +9,7 @@
 * Fix for vmware installer failure to build vmmon and vmnet kernel modules
 * as random_get_entropy_fallback() is not found in this unit.
 */
-unsigned long random_get_entropy_fallback(void);
+extern unsigned long random_get_entropy_fallback(void);
 
 static inline unsigned long random_get_entropy(void)
 {

--- a/arch/x86/include/asm/timex.h
+++ b/arch/x86/include/asm/timex.h
@@ -5,6 +5,13 @@
 #include <asm/processor.h>
 #include <asm/tsc.h>
 
+/*
+Fixes failure of vmware installer to build vmmon and vmnet kernel modules
+as random_get_entropy_fallback() is not found in the included files from this
+file.
+*/
+extern unsigned long random_get_entropy_fallback(void);
+
 static inline unsigned long random_get_entropy(void)
 {
 	if (!IS_ENABLED(CONFIG_X86_TSC) &&


### PR DESCRIPTION
Fixes failure of vmware installer to build vmmon and vmnet kernel modules as random_get_entropy_fallback() is not found in the included files from this file.
the commit  [3bd4abc](https://github.com/torvalds/linux/commit/3bd4abc07a267e6a8b33d7f8717136e18f921c53)  is the cause of this issue.
