### PR TITLE
Change the severity of missing UUID from warning to notice

### DIFF
--- a/drivers/nvme/host/sysfs.c
+++ b/drivers/nvme/host/sysfs.c
@@ -147,7 +147,7 @@ static ssize_t uuid_show(struct device *dev, struct device_attribute *attr,
 	 * we have no UUID set
 	 */
 	if (uuid_is_null(&ids->uuid)) {
-		dev_warn_once(dev,
+		dev_notice_once(dev,
 			"No UUID available providing old NGUID\n");
 		return sysfs_emit(buf, "%pU\n", ids->nguid);
 	}


### PR DESCRIPTION
This message is currently logged as a warning but it's not actionable and according to Keith Busch "It's a harmless informative message".