### PR TITLE
Corrected typos in arch/arm/include/asm/efi.h and kernel/trace/rv/Kco…

### DIFF
--- a/arch/arm/include/asm/efi.h
+++ b/arch/arm/include/asm/efi.h
@@ -59,7 +59,7 @@ void efi_virtmap_unload(void);
 /*
  * A reasonable upper bound for the uncompressed kernel size is 32 MBytes,
  * so we will reserve that amount of memory. We have no easy way to tell what
- * the actuall size of code + data the uncompressed kernel will use.
+ * the actual size of code + data the uncompressed kernel will use.
  * If this is insufficient, the decompressor will relocate itself out of the
  * way before performing the decompression.
  */

--- a/kernel/trace/rv/Kconfig
+++ b/kernel/trace/rv/Kconfig
@@ -45,7 +45,7 @@ config RV_MON_WWNR
 	help
 	  Enable wwnr (wakeup while not running) sample monitor, this is a
 	  sample monitor that illustrates the usage of per-task monitor.
-	  The model is borken on purpose: it serves to test reactors.
+	  The model is broken on purpose: it serves to test reactors.
 
 	  For further information, see:
 	    Documentation/trace/rv/monitor_wwnr.rst


### PR DESCRIPTION
Subject: Correct typos in arch/arm/include/asm/efi.h and kernel/trace/rv/Kconfig

- Fixed minor typos in arch/arm/include/asm/efi.h and kernel/trace/rv/Kconfig files.

Changes made:
- In arch/arm/include/asm/efi.h:
  - Corrected "actuall" to "actual" in the comment regarding kernel size estimation.

- In kernel/trace/rv/Kconfig:
  - Rectified "borken" to "broken" in the description of the model's purpose.

Signed-off-by: Clement YAHIA-AMAR <clementamar@gmail.com>
