### PR TITLE
Fix: Clear OS bit in RTC register after low voltage condition

### DIFF
--- a/drivers/rtc/rtc-pcf85063.c
+++ b/drivers/rtc/rtc-pcf85063.c
@@ -586,6 +586,16 @@ static int pcf85063_probe(struct i2c_client *client)
 		return err;
 	}
 
+	ret = regmap_read(pcf85063->regmap, PCF85063_REG_SC, &tmp);
+	if (ret < 0)
+		return ret;
+
+	// cleat the OS Bit if it is set
+	if ((tmp & (1 << (8 - 1)))) {
+		tmp = tmp & (~(1 << (8 - 1)));
+		regmap_write(pcf85063->regmap, PCF85063_REG_SC, tmp);
+	}
+	
 	pcf85063->rtc = devm_rtc_allocate_device(&client->dev);
 	if (IS_ERR(pcf85063->rtc))
 		return PTR_ERR(pcf85063->rtc);


### PR DESCRIPTION
**Code changes:**

Check the oscillator stop (OS) bit during RTC initialization. If the OS bit is set due to a low voltage condition (e.g., drained super capacitor), clear it to reinitialize the oscillator. Problem study:
The oscillator stop bit of the External RTC Register must be cleared manually to make it functional. When the RTC receives low voltage, it triggers the OS bit to be set.

**Scenario:**
When the super capacitor voltage is drained, the OS bit is set, indicating that the oscillator has stopped. For all subsequent initializations, this OS bit needs to be manually cleared to ensure the RTC operates correctly.

**Datasheet:**

![rtc os bit](https://github.com/torvalds/linux/assets/34344962/f6805408-59f2-4c41-b863-7d7fb8a34999)
