### PR TITLE
Overlapping write union fix.

### DIFF
--- a/arch/alpha/kernel/rtc.c
+++ b/arch/alpha/kernel/rtc.c
@@ -155,11 +155,18 @@ union remote_data {
 	long retval;
 };
 
-static void
-do_remote_read(void *data)
+static void do_remote_read(void *data)
 {
-	union remote_data *x = data;
-	x->retval = alpha_rtc_read_time(NULL, x->tm);
+    union remote_data *x = data;
+    // Use temporary variables to avoid overlapping read/write
+    struct tm temp_tm;
+    int temp_retval;
+    
+    temp_retval = alpha_rtc_read_time(NULL, &temp_tm);
+    
+    // Now copy the temporary values into the union
+    x->tm = temp_tm;
+    x->retval = temp_retval;
 }
 
 static int
@@ -174,11 +181,17 @@ remote_read_time(struct device *dev, struct rtc_time *tm)
 	return alpha_rtc_read_time(NULL, tm);
 }
 
-static void
-do_remote_set(void *data)
+static void do_remote_set(void *data)
 {
-	union remote_data *x = data;
-	x->retval = alpha_rtc_set_time(NULL, x->tm);
+    union remote_data *x = data;
+    // Use a temporary variable to avoid overlapping read/write
+    struct tm temp_tm = x->tm;
+    int temp_retval;
+    
+    temp_retval = alpha_rtc_set_time(NULL, &temp_tm);
+    
+    // Now copy the temporary retval into the union
+    x->retval = temp_retval;
 }
 
 static int


### PR DESCRIPTION
Fixed 2 errors by using a temporary variable to avoid overlapping read/write.

On `linux/arch/alpha/kernel/rtc.c` and lines:

- `rtc.c`:162:12: error: Overlapping read/write of union is undefined behavior [overlappingWriteUnion]
- `rtc.c`:188:12: error: Overlapping read/write of union is undefined behavior [overlappingWriteUnion]

