### PR TITLE
Add support for Mission 778X integrated DAC/amplifier

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1939,6 +1939,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x22e1, 0xca01): /* HDTA Serenade DSD */
 	case USB_ID(0x249c, 0x9326): /* M2Tech Young MkIII */
 	case USB_ID(0x2616, 0x0106): /* PS Audio NuWave DAC */
+	case USB_ID(0x2622, 0x0011): /* Mission 778X */
 	case USB_ID(0x2622, 0x0041): /* Audiolab M-DAC+ */
 	case USB_ID(0x278b, 0x5100): /* Rotel RC-1590 */
 	case USB_ID(0x27f7, 0x3002): /* W4S DAC-2v2SE */


### PR DESCRIPTION
It's a XMOS USB chip based DAC with native DSD support up to DSD256