### PR TITLE
Update procfs-i8k

### DIFF
--- a/Documentation/ABI/obsolete/procfs-i8k
+++ b/Documentation/ABI/obsolete/procfs-i8k
@@ -3,7 +3,7 @@ Date:		November 2001
 KernelVersion:	2.4.14
 Contact:	Pali Rohár <pali@kernel.org>
 Description:	Legacy interface for getting/setting sensor information like
-		fan speed, temperature, serial number, hotkey status etc
+		fan speed, temperature, serial number, hotkey status, etc.
 		on Dell Laptops.
 		Since the driver is now using the standard hwmon sysfs interface,
 		the procfs interface is deprecated.


### PR DESCRIPTION
The abbreviation etc. always ends with a period, regardless of any additional punctuation that may follow. A comma precedes the use of “etc.,” whether abbreviated or written as “et cetera,” because it’s another item on the list.