### PR TITLE
thermal: core: Add emulated temperature offset for stress testing

### DIFF
--- a/Documentation/driver-api/thermal/sysfs-api.rst
+++ b/Documentation/driver-api/thermal/sysfs-api.rst
@@ -88,6 +88,9 @@ temperature) and throttle appropriate devices.
 	.set_emul_temp:
 			set the emulation temperature which helps in debugging
 			different threshold temperature points.
+	.set_emul_offset:
+			set the emulated offset temperature which helps in simulating
+			thermal stress at a higher ambient temperature.
     tzp:
 	thermal zone platform parameters.
     passive_delay:
@@ -145,6 +148,8 @@ temperature) and throttle appropriate devices.
 					sensor temperature trend.
 			set_emul_temp	a pointer to a function that sets
 					sensor emulated temperature.
+			set_emul_offset	a pointer to a function that sets
+					sensor emulated offset temperature.
 			==============  =======================================
 
 	The thermal zone temperature is provided by the get_temp() function

--- a/include/linux/thermal.h
+++ b/include/linux/thermal.h
@@ -93,6 +93,7 @@ struct thermal_zone_device_ops {
 	int (*set_trip_temp) (struct thermal_zone_device *, int, int);
 	int (*get_crit_temp) (struct thermal_zone_device *, int *);
 	int (*set_emul_temp) (struct thermal_zone_device *, int);
+	int (*set_emul_offset) (struct thermal_zone_device *, int);
 	int (*get_trend) (struct thermal_zone_device *,
 			  const struct thermal_trip *, enum thermal_trend *);
 	void (*hot)(struct thermal_zone_device *);


### PR DESCRIPTION
This commit adds an emulated temperature offset to the Linux kernel, allowing for simulation of higher ambient temperatures. This feature is useful for thermal stress testing and debugging, as it enables testing of form factor devices at room temperature while making them believe they are in a thermal chamber. The offset can be adjusted to simulate different temperatures, allowing for more flexibility in testing and debugging. This commit brings the benefits of thermal chamber testing to on-desk devices, making it easier to test and debug user-experience and expected operational time.