### PR TITLE
bpf: fix bpf_probe_read documentation

### DIFF
--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -1876,7 +1876,8 @@ union bpf_attr {
  * long bpf_probe_read(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
  * 		For tracing programs, safely attempt to read *size* bytes from
- * 		kernel space address *unsafe_ptr* and store the data in *dst*.
+ * 		user or kernel space address *unsafe_ptr* and store the
+ * 		data in *dst*.
  *
  * 		Generally, use **bpf_probe_read_user**\ () or
  * 		**bpf_probe_read_kernel**\ () instead.
@@ -2759,9 +2760,8 @@ union bpf_attr {
  *
  * long bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
- * 		Copy a NUL terminated string from an unsafe kernel address
- * 		*unsafe_ptr* to *dst*. See **bpf_probe_read_kernel_str**\ () for
- * 		more details.
+ * 		Copy a NUL terminated string from an unsafe user or kernel
+ * 		address *unsafe_ptr* to *dst*.
  *
  * 		Generally, use **bpf_probe_read_user_str**\ () or
  * 		**bpf_probe_read_kernel_str**\ () instead.

--- a/tools/include/uapi/linux/bpf.h
+++ b/tools/include/uapi/linux/bpf.h
@@ -1876,7 +1876,8 @@ union bpf_attr {
  * long bpf_probe_read(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
  * 		For tracing programs, safely attempt to read *size* bytes from
- * 		kernel space address *unsafe_ptr* and store the data in *dst*.
+ * 		user or kernel space address *unsafe_ptr* and store the
+ * 		data in *dst*.
  *
  * 		Generally, use **bpf_probe_read_user**\ () or
  * 		**bpf_probe_read_kernel**\ () instead.
@@ -2759,9 +2760,8 @@ union bpf_attr {
  *
  * long bpf_probe_read_str(void *dst, u32 size, const void *unsafe_ptr)
  * 	Description
- * 		Copy a NUL terminated string from an unsafe kernel address
- * 		*unsafe_ptr* to *dst*. See **bpf_probe_read_kernel_str**\ () for
- * 		more details.
+ * 		Copy a NUL terminated string from an unsafe user or kernel
+ * 		address *unsafe_ptr* to *dst*.
  *
  * 		Generally, use **bpf_probe_read_user_str**\ () or
  * 		**bpf_probe_read_kernel_str**\ () instead.


### PR DESCRIPTION
Fix bpf_probe_read documentation. Previously, the description might confuse because of the statement that bpf_probe_read function reads data from kernel space address only. In fact it compares passing address and TASK_SIZE, and then delegates execution to bpf_probe_read_user or bpf_probe_read_kernel functions.