### PR TITLE
fix bug for AF3x User Priority mapping

### DIFF
--- a/net/wireless/util.c
+++ b/net/wireless/util.c
@@ -998,7 +998,6 @@ unsigned int cfg80211_classify8021d(struct sk_buff *skb,
 	 * Diffserv Service Classes no update is needed:
 	 * - Standard: DF
 	 * - Low Priority Data: CS1
-	 * - Multimedia Streaming: AF31, AF32, AF33
 	 * - Multimedia Conferencing: AF41, AF42, AF43
 	 * - Network Control Traffic: CS7
 	 * - Real-Time Interactive: CS4
@@ -1024,6 +1023,12 @@ unsigned int cfg80211_classify8021d(struct sk_buff *skb,
 		break;
 	case 24:
 		/* Broadcasting video: CS3 */
+		ret = 4;
+		break;
+	case 26:
+	case 28:
+	case 30:
+		/* Multimedia Streaming: AF31, AF32, AF33 */
 		ret = 4;
 		break;
 	case 40:


### PR DESCRIPTION
According to [RFC8325 4.3](https://datatracker.ietf.org/doc/html/rfc8325#section-4.3), Multimedia Streaming: **AF31**(011010, 26), **AF32**(011100, 28), **AF33**(011110, 30) maps to User Priority = 4 and AC_VI (Video). 



However, the original code remain the default three Most Significant Bits (MSBs) of the DSCP, which makes AF3x map to User Priority = 3 and AC_BE (Best Effort).