### PR TITLE
Ensure that brcmfmac pcie devices are properly reset at shutdown

### DIFF
--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
@@ -2711,6 +2711,7 @@ static struct pci_driver brcmf_pciedrvr = {
 	.id_table = brcmf_pcie_devid_table,
 	.probe = brcmf_pcie_probe,
 	.remove = brcmf_pcie_remove,
+	.shutdown = brcmf_pcie_remove,
 #ifdef CONFIG_PM
 	.driver.pm = &brcmf_pciedrvr_pm,
 #endif


### PR DESCRIPTION
Some BCM devices, such as the BCM43602, are left in an inconsistent internal state upon shutdown. Normally, this would not be important as the device would be powered down following the shutdown.

However, in an emulated environment such as Linux in a VM, the device becomes inoperable unless a complete powerdown of the device occurs.

This issue fixes various reports online such as https://github.com/QubesOS/qubes-issues/issues/3734, https://bugzilla.redhat.com/show_bug.cgi?format=multiple&id=1294415, https://www.reddit.com/r/hackintosh/comments/c38u1l/problem_with_pci_passthrough_broadcom_wifi_card/, and so on.