### PR TITLE
asm: Fix "impossible constraint in ‘asm’" error by replacing __auto_type with enum in __WARN_FLAGS macro

### DIFF
--- a/arch/x86/include/asm/bug.h
+++ b/arch/x86/include/asm/bug.h
@@ -90,7 +90,7 @@ do {								\
  */
 #define __WARN_FLAGS(flags)					\
 do {								\
-	__auto_type __flags = BUGFLAG_WARNING|(flags);		\
+	enum{ __flags = BUGFLAG_WARNING|(flags)};		    \
 	instrumentation_begin();				\
 	_BUG_FLAGS(ASM_UD2, __flags, ASM_REACHABLE);		\
 	instrumentation_end();					\


### PR DESCRIPTION
**Commit Message:**

When adding `__attribute__((optimize("O0")))` before a function containing `WARN_ON_ONCE`, compilation fails (with GCC v9.4.0), producing the following error:

```
./include/linux/compiler_types.h:445:20: error: impossible constraint in ‘asm’
  445 | #define asm_inline asm __inline
      |                    ^~~
./arch/x86/include/asm/bug.h:28:2: note: in expansion of macro ‘asm_inline’
   28 |  asm_inline volatile("1:\t" ins "\n"    \
      |  ^~~~~~~~~~
./arch/x86/include/asm/bug.h:82:2: note: in expansion of macro ‘_BUG_FLAGS’
   82 |  _BUG_FLAGS(ASM_UD2, __flags, ASM_REACHABLE);  \
      |  ^~~~~~~~~~
./include/asm-generic/bug.h:113:3: note: in expansion of macro ‘__WARN_FLAGS’
  113 |   __WARN_FLAGS(BUGFLAG_ONCE |   \
      |   ^~~~~~~~~~~~
arch/x86/kvm/x86.c:9291:3: note: in expansion of macro ‘WARN_ON_ONCE’
 9291 |   WARN_ON_ONCE(vcpu->mmio_needed && !vcpu->mmio_is_write);
      |   ^~~~~~~~~~~~
```

This error occurs because, when optimizations are disabled (`-O0`), the `flags` parameter in `_BUG_FLAGS` is not a compile-time constant. Specifically, in the `__WARN_FLAGS` macro, `__auto_type __flags = BUGFLAG_WARNING | (flags);` declares` __flags` as a variable. Variables cannot be used as immediate operands in inline assembly with the `"i"` constraint.

This issue makes debugging troublesome, as disabling optimizations is a common practice during debugging to get accurate line-by-line execution.

To fix this problem, replace the declaration of `__flags` with an `enum` constant in the `__WARN_FLAGS` macro:

```c
#define __WARN_FLAGS(flags)                                   \
do {                                                          \
    enum { __flags = BUGFLAG_WARNING | (flags) };             \
    instrumentation_begin();                                  \
    _BUG_FLAGS(ASM_UD2, __flags, ASM_REACHABLE);              \
    instrumentation_end();                                    \
} while (0)
```

This change ensures that `__flags` is a compile-time constant, satisfying the `"i"` constraint in the inline assembly, and prevents the compilation error when optimizations are disabled.
