### PR TITLE
Fix for ID 0408:4033 Quanta ACER HD User Facing Camera

### DIFF
--- a/drivers/media/usb/uvc/uvc_driver.c
+++ b/drivers/media/usb/uvc/uvc_driver.c
@@ -2430,6 +2430,24 @@ static const struct uvc_device_info uvc_quirk_force_y8 = {
  * though they are compliant.
  */
 static const struct usb_device_id uvc_ids[] = {
+	/**
+	   * Fix for the problem with cameras on Acer Nitro 5 Series & Acer Aspire 3 Series.
+	   * 
+	   * Fix required for the camera here
+	   * Thanks for @Giuliano69 for providing the fix
+	  */
+	/* Quanta ACER HD User Facing 4033 - Experimental !! */
+	{ .match_flags 		= USB_DEVICE_ID_MATCH_DEVICE 
+		       		| USB_DEVICE_ID_MATCH_INT_INFO,
+	  .idVendor 		= 0x0408,
+	  .idProduct 		= 0x4033,
+	  .bInterfaceClass 	= USB_CLASS_VIDEO,
+	  .bInterfaceSubClass 	= 1,
+	  .bInterfaceProtocol 	= UVC_PC_PROTOCOL_15,
+	  .driver_info 		= (kernel_ulong_t)&(const struct uvc_device_info){
+		.uvc_version 	= 0x010a,
+	  } },
+	/* Fix end here */
 	/* Quanta ACER HD User Facing */
 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
 				| USB_DEVICE_ID_MATCH_INT_INFO,


### PR DESCRIPTION
This issue has mainly arises in the newer Acer Aspire 3 Series Laptops, where the cameras with this specific `ID 0408:4033` were not working on linux. 

After doing some extensive research a fix was found @Giuliano69 which solved the issue. This PR aims to implement that fix in the main kernel so that this issue gets fixed for all.
This issue was also referenced in this PR #843 but was left unattended and wasn't merged into the kernel, specifically the fix for ID 0408:4033, whereas ID 0408:4035 was merged.
Let's get this merged too, so that the issue is fixed for all users who are facing it.