### PR TITLE
perf evsel: display dmesg command of showing a hardcoded path

### DIFF
--- a/tools/perf/util/evsel.c
+++ b/tools/perf/util/evsel.c
@@ -3415,7 +3415,7 @@ int evsel__open_strerror(struct evsel *evsel, struct target *target,
 
 	return scnprintf(msg, size,
 	"The sys_perf_event_open() syscall returned with %d (%s) for event (%s).\n"
-	"/bin/dmesg | grep -i perf may provide additional information.\n",
+	"\"dmesg | grep -i perf\" may provide additional information.\n",
 			 err, str_error_r(err, sbuf, sizeof(sbuf)), evsel__name(evsel));
 }
 


### PR DESCRIPTION
In non-FHS compliant distros like NixOS, nothing resides in `/bin` and `/usr/bin`. Instead dynamically symlinked into `/run/current-system/sw/bin/`, the executable resides in `/nix/store`.

With this patch,`/bin` prefix from the dmesg command in the error message is stripped.

Link: https://github.com/NixOS/nixpkgs/pull/258027

> [!NOTE]
> I know this is not the place to submit patches and I have already submitted the patch on the mailing list, this is just for testing purposes.