### PR TITLE
Remove the distracting '=' header

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,4 @@
 Linux kernel
-============
 
 There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read


### PR DESCRIPTION
If you view the README in an editor that doesn't use a monospace font, the header looks a little too long and it's a little distracting when you're trying to appreciate the Linux source code.

There has been another past pull request to fix this issue by removing a '=' so that the header looks fine with a font that isn't monospace (#933) but unfortunately it was critiqued because then the header would look bad in most editors that use a monospace font.

I propose this solution that will benefit both sides: if we remove the header, we remove the problem, so that everyone may gaze at the README in peace.