### PR TITLE
Transition to SCTP_ACTIVE on receiving SACK (Single-homed Association)

### DIFF
--- a/net/sctp/outqueue.c
+++ b/net/sctp/outqueue.c
@@ -1637,7 +1637,8 @@ static void sctp_check_transmitted(struct sctp_outq *q,
 			/* Mark the destination transport address as
 			 * active if it is not so marked.
 			 */
-			if ((transport->state == SCTP_INACTIVE ||
+			if ((transport->state == SCTP_PF ||
+			     transport->state == SCTP_INACTIVE ||
 			     transport->state == SCTP_UNCONFIRMED) &&
 			    sctp_cmp_addr_exact(&transport->ipaddr, saddr)) {
 				sctp_assoc_control_transport(


### PR DESCRIPTION
Handle the following case:

Link: https://datatracker.ietf.org/doc/rfc7829/

3.2.  Specification of the SCTP-PF Procedures
10.  Acknowledgments for data chunks that have been transmitted to one destination address only MUST clear the error counter for the destination address and MUST transition a destination address in PF state back to active state.