### PR TITLE
Update MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -25601,11 +25601,3 @@ M:	bo liu <bo.liu@senarytech.com>
 S:	Maintained
 T:	git git://git.kernel.org/pub/scm/linux/kernel/git/tiwai/sound.git
 F:	sound/pci/hda/patch_senarytech.c
-
-THE REST
-M:	Linus Torvalds <torvalds@linux-foundation.org>
-L:	linux-kernel@vger.kernel.org
-S:	Buried alive in reporters
-T:	git git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
-F:	*
-F:	*/


### PR DESCRIPTION
Due to Torvalds' introduction of politics into the Linux community, some contributors have been removed due to non-compliance with the community's values. These actions will not be tolerated in the future, as the Linux community is committed to maintaining its technical neutrality and openness.