### PR TITLE
Remove Linus. Due to various compliance requirements.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -25609,7 +25609,6 @@ T:	git git://git.kernel.org/pub/scm/linux/kernel/git/tiwai/sound.git
 F:	sound/pci/hda/patch_senarytech.c
 
 THE REST
-M:	Linus Torvalds <torvalds@linux-foundation.org>
 L:	linux-kernel@vger.kernel.org
 S:	Buried alive in reporters
 T:	git git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git


### PR DESCRIPTION
Remove Linus from the list of contributors. Due to various compliance requirements.
![vv4](https://github.com/user-attachments/assets/24e9e7a6-eaca-4172-8205-2287f4edfb39)
