### PR TITLE
Update tsacct.c

### DIFF
--- a/kernel/tsacct.c
+++ b/kernel/tsacct.c
@@ -154,10 +154,10 @@ void acct_update_integrals(struct task_struct *tsk)
 	u64 utime, stime;
 	unsigned long flags;
 
-	local_irq_save(flags);
+	spin_lock_irqsave(&tsk->mm->page_table_lock, flags);
 	task_cputime(tsk, &utime, &stime);
 	__acct_update_integrals(tsk, utime, stime);
-	local_irq_restore(flags);
+	spin_unlock_irqrestore(&tsk->mm->page_table_lock, flags);
 }
 
 /**


### PR DESCRIPTION
Optimize acct_update_integrals by replacing local_irq_save with a more fine-grained spinlock (tsk->mm->page_table_lock) to reduce locking overhead. This minimizes the time interrupts are disabled while still ensuring the integrity of the accounting data.