### PR TITLE
missing backticks in README

### DIFF
--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use ``make htmldocs`` or
-``make pdfdocs``.  The formatted documentation can also be read online at:
+In order to build the documentation, use ```make htmldocs``` or
+```make pdfdocs```.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 


### PR DESCRIPTION
updated the readme.md because the make pdfdocsb and make htmldocs only had 2 backticks and it didn't work as intended. I added the necessary backticks to improve readability and less confusion for the visitors