### PR TITLE
make r8169 great like r8168

### DIFF
--- a/drivers/net/ethernet/realtek/r8169_main.c
+++ b/drivers/net/ethernet/realtek/r8169_main.c
@@ -66,8 +66,8 @@
 
 #define R8169_REGS_SIZE		256
 #define R8169_RX_BUF_SIZE	(SZ_16K - 1)
-#define NUM_TX_DESC	256	/* Number of Tx descriptor registers */
-#define NUM_RX_DESC	256	/* Number of Rx descriptor registers */
+#define NUM_TX_DESC	1024	/* Number of Tx descriptor registers */
+#define NUM_RX_DESC	1024	/* Number of Rx descriptor registers */
 #define R8169_TX_RING_BYTES	(NUM_TX_DESC * sizeof(struct TxDesc))
 #define R8169_RX_RING_BYTES	(NUM_RX_DESC * sizeof(struct RxDesc))
 #define R8169_TX_STOP_THRS	(MAX_SKB_FRAGS + 1)


### PR DESCRIPTION
that is my ring when I use r8169:

```
$ethtool -g enp1s0
Ring parameters for enp1s0:
Pre-set maximums:
RX:                     255
RX Mini:                n/a
RX Jumbo:               n/a
TX:                     255
TX push buff len:       n/a
```

and that is my ring when I use r8168:

```
$ethtool -g enp1s0
Ring parameters for enp1s0:
Pre-set maximums:
RX:                     1024
RX Mini:                n/a
RX Jumbo:               n/a
TX:                     1024
TX push buff len:       n/a
```

Is that an attempt to censor my traffic? I don't like it.
I fixed it, anyway.
open your eyes guys!
Bye.