### PR TITLE
input: revert commit 9140ce4 to fix ELAN1206 touchpad issues

### DIFF
--- a/drivers/dma/idma64.c
+++ b/drivers/dma/idma64.c
@@ -171,9 +171,10 @@ static irqreturn_t idma64_irq(int irq, void *dev)
 	u32 status_err;
 	unsigned short i;
 
+	/* Commented to restore ELAN1206 Touchpad functionality */
 	/* Since IRQ may be shared, check if DMA controller is powered on */
-	if (status == GENMASK(31, 0))
-		return IRQ_NONE;
+	// if (status == GENMASK(31, 0))
+	// 	return IRQ_NONE;
 
 	dev_vdbg(idma64->dma.dev, "%s: status=%#x\n", __func__, status);
 


### PR DESCRIPTION
## Description
Reverting commit [9140ce4](https://github.com/torvalds/linux/commit/9140ce47872bfd89fca888c2f992faa51d20c2bc) fixes a regression that caused touchpad malfunctions. The original change introduced unintended behavior affecting touchpad input with the ELAN1206. 
## Touchpad Behavior with 9140ce4
The touchpad appears to send an event indicating touch up immediatly after each touch down event. This prevents libinput from moving the cursor rendering the touchpad useless. It is also worth noting that in addition to incorrect events the touchpad also appears to send events much less frequently.
`evtest`:
```
Event: time 1738819278.422243, type 3 (EV_ABS), code 57 (ABS_MT_TRACKING_ID), value 73
Event: time 1738819278.422243, type 3 (EV_ABS), code 53 (ABS_MT_POSITION_X), value 1264
Event: time 1738819278.422243, type 3 (EV_ABS), code 54 (ABS_MT_POSITION_Y), value 860
Event: time 1738819278.422243, type 1 (EV_KEY), code 330 (BTN_TOUCH), value 1
Event: time 1738819278.422243, type 1 (EV_KEY), code 325 (BTN_TOOL_FINGER), value 1
Event: time 1738819278.422243, type 3 (EV_ABS), code 0 (ABS_X), value 1264
Event: time 1738819278.422243, type 3 (EV_ABS), code 1 (ABS_Y), value 860
Event: time 1738819278.422243, type 4 (EV_MSC), code 5 (MSC_TIMESTAMP), value 0
Event: time 1738819278.422243, -------------- SYN_REPORT ------------
Event: time 1738819278.526021, type 3 (EV_ABS), code 57 (ABS_MT_TRACKING_ID), value -1
Event: time 1738819278.526021, type 1 (EV_KEY), code 330 (BTN_TOUCH), value 0
Event: time 1738819278.526021, type 1 (EV_KEY), code 325 (BTN_TOOL_FINGER), value 0
Event: time 1738819278.526021, -------------- SYN_REPORT ------------
Event: time 1738819278.630874, type 3 (EV_ABS), code 57 (ABS_MT_TRACKING_ID), value 74
Event: time 1738819278.630874, type 3 (EV_ABS), code 53 (ABS_MT_POSITION_X), value 1415
Event: time 1738819278.630874, type 3 (EV_ABS), code 54 (ABS_MT_POSITION_Y), value 799
```
## Touchpad Behavior without 9140ce4
The touchpad functions smoothly and consistently.
## Fixes
closes: [https://bugzilla.kernel.org/show_bug.cgi?id=219799](https://bugzilla.kernel.org/show_bug.cgi?id=219799) (an issue I opened)
## Impacts
Reverting [9140ce4](https://github.com/torvalds/linux/commit/9140ce47872bfd89fca888c2f992faa51d20c2bc) would theoretically reopen [https://lore.kernel.org/r/700bbb84-90e1-4505-8ff0-3f17ea8bc631@gmail.com](https://lore.kernel.org/r/700bbb84-90e1-4505-8ff0-3f17ea8bc631@gmail.com)
## Methods
I bisected the Linux kernel and found that [9140ce4](https://github.com/torvalds/linux/commit/9140ce47872bfd89fca888c2f992faa51d20c2bc) was the first commit where my touchpad didn't work. Building the latest kernel with [9140ce4](https://github.com/torvalds/linux/commit/9140ce47872bfd89fca888c2f992faa51d20c2bc) removed resulted in a working touchpad.

I haven't made a pull request before so apologies if mistakes are present. Please let me know if I can help in any way.