### PR TITLE
Update main.c with peace message during boot

### DIFF
--- a/init/main.c
+++ b/init/main.c
@@ -915,6 +915,7 @@ void start_kernel(void)
 	boot_cpu_init();
 	page_address_init();
 	pr_notice("%s", linux_banner);
+	pr_notice("PAX: This is a peaceful software!\n");
 	setup_arch(&command_line);
 	/* Static keys and static calls are needed by LSMs */
 	jump_label_init();


### PR DESCRIPTION
Add peace message to kernel logs

This commit adds a simple message to the kernel logs: "PAX: This is a peaceful software!"

The message appears right after the Linux version banner during boot and serves as a reminder that open-source software should promote peace and collaboration.

This change does not affect functionality and is purely informational.

Signed-off-by: Hendrik Joachim Rennefeld