### PR TITLE
Add EDID_QUIRK for Playstation VR Headsets with Product ID 0xB403

### DIFF
--- a/drivers/gpu/drm/drm_edid.c
+++ b/drivers/gpu/drm/drm_edid.c
@@ -237,8 +237,9 @@ static const struct edid_quirk {
 	EDID_QUIRK('S', 'E', 'C', 0x144a, EDID_QUIRK_NON_DESKTOP),
 	EDID_QUIRK('A', 'U', 'S', 0xc102, EDID_QUIRK_NON_DESKTOP),
 
-	/* Sony PlayStation VR Headset */
+	/* Sony PlayStation VR Headsets */
 	EDID_QUIRK('S', 'N', 'Y', 0x0704, EDID_QUIRK_NON_DESKTOP),
+	EDID_QUIRK('S', 'N', 'Y', 0xB403, EDID_QUIRK_NON_DESKTOP)
 
 	/* Sensics VR Headsets */
 	EDID_QUIRK('S', 'E', 'N', 0x1019, EDID_QUIRK_NON_DESKTOP),


### PR DESCRIPTION
This fixes a bug where some Playstation VR Headsets would not be assigned the EDID_QUIRK_NON_DESKTOP quirk, causing them to be inaccessible by certain software under Wayland.