### PR TITLE
Correct single-character typo in idpf kconfig

### DIFF
--- a/drivers/net/ethernet/intel/idpf/Kconfig
+++ b/drivers/net/ethernet/intel/idpf/Kconfig
@@ -21,6 +21,6 @@ config IDPF_SINGLEQ
 	  This option enables support for legacy single Rx/Tx queues w/no
 	  completion and fill queues. Only enable if you have hardware which
 	  wants to work in this mode as it increases the driver size and adds
-	  runtme checks on hotpath.
+	  runtime checks on hotpath.
 
 endif # IDPF


### PR DESCRIPTION
"runtme" -> runtime.

The most minor of PRs possible!