### PR TITLE
Update exit.c

### DIFF
--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -1741,6 +1741,15 @@ int kernel_waitid_prepare(struct wait_opts *wo, int which, pid_t upid,
 
 		pid = find_get_pid(upid);
 		break;
+	case P_SID:
+		type = PIDTYPE_SID;
+		if (upid < 0)
+			return -EINVAL;
+
+		if (upid)
+			pid = find_get_pid(upid);
+		else
+			pid = get_task_pid(current, PIDTYPE_SID);
 	case P_PGID:
 		type = PIDTYPE_PGID;
 		if (upid < 0)


### PR DESCRIPTION
The P_SID case was added to let the waitid system call wait for any child process that's part of a specific session ID (SID). A session is basically a group of process groups, usually linked to a controlling terminal.

Now, why would you wanna wait for processes by their session ID? Well, it's super useful in cases where you need to keep an eye on all processes tied to a particular user's login session or maybe a specific service session. Like, imagine a session leader—maybe a shell or a service manager—that wants to wait until all its child processes are done and terminated before moving forward.