### PR TITLE
String Consistency

### DIFF
--- a/drivers/media/usb/ttusb-dec/ttusb_dec.c
+++ b/drivers/media/usb/ttusb-dec/ttusb_dec.c
@@ -32,11 +32,11 @@ static int output_pva;
 static int enable_rc;
 
 module_param(debug, int, 0644);
-MODULE_PARM_DESC(debug, "Turn on/off debugging (default:off).");
+MODULE_PARM_DESC(debug, "Turn on/off debugging (default:off)");
 module_param(output_pva, int, 0444);
 MODULE_PARM_DESC(output_pva, "Output PVA from dvr device (default:off)");
 module_param(enable_rc, int, 0644);
-MODULE_PARM_DESC(enable_rc, "Turn on/off IR remote control(default: off)");
+MODULE_PARM_DESC(enable_rc, "Turn on/off IR remote control (default:off)");
 
 DVB_DEFINE_MOD_OPT_ADAPTER_NR(adapter_nr);
 


### PR DESCRIPTION
Literally just fixed string formatting to make them more consistent. Will email this as a patch later, simply creating this request as a reminder to myself.

Original
```C
module_param(debug, int, 0644);
MODULE_PARM_DESC(debug, "Turn on/off debugging (default:off).");
module_param(output_pva, int, 0444);
MODULE_PARM_DESC(output_pva, "Output PVA from dvr device (default:off)");
module_param(enable_rc, int, 0644);
MODULE_PARM_DESC(enable_rc, "Turn on/off IR remote control(default: off)");
```

Fixed
```C
module_param(debug, int, 0644);
MODULE_PARM_DESC(debug, "Turn on/off debugging (default:off)"); // Removed '.' at the end
module_param(output_pva, int, 0444);
MODULE_PARM_DESC(output_pva, "Output PVA from dvr device (default:off)");
module_param(enable_rc, int, 0644);
MODULE_PARM_DESC(enable_rc, "Turn on/off IR remote control (default:off)"); // Added ' ' between 'control' and ' ' -- Removed space between ':' and 'off'
```