### PR TITLE
HID: playstation: DS4: Add BT poll interval adjustment

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -4001,6 +4001,10 @@ S: 44 Campbell Park Crescent
 S: Edinburgh EH13 0HT
 S: United Kingdom
 
+N: Vadym Tytan
+E: titanv3585@gmail.com
+D: Minor game controllers features
+
 N: Thomas Uhl
 E: uhl@sun1.rz.fh-heilbronn.de
 D: Application programmer


### PR DESCRIPTION
Restores ability to adjust Bluetooth poll interval for DualShock4, that was lost after moving from [linux/drivers/hid/hid-sony.c (v6.1)](https://github.com/torvalds/linux/blob/v6.1/drivers/hid/hid-sony.c) to [linux/drivers/hid/hid-playstation.c (v6.2)](https://github.com/torvalds/linux/blob/v6.2/drivers/hid/hid-playstation.c)