### PR TITLE
Set NVME_QUIRK_BOGUS_NSID quirk flag for devices with Vendor ID:0x144d Device ID:0xa824 Subsystem Vendor id:0x108e

### DIFF
--- a/drivers/nvme/host/pci.c
+++ b/drivers/nvme/host/pci.c
@@ -3163,6 +3163,13 @@ static unsigned long check_vendor_combination_bug(struct pci_dev *pdev)
 		    dmi_match(DMI_BOARD_NAME, "PH4PRX1_PH6PRX1") ||
 		    dmi_match(DMI_BOARD_NAME, "PH6PG01_PH6PG71"))
 			return NVME_QUIRK_FORCE_NO_SIMPLE_SUSPEND;
+	} else if (pdev->vendor == 0x144d && pdev->device == 0xa824 &&
+                       pdev->subsystem_vendor == 0x108e) {
+		/*
+		 * Set NVME_QUIRK_BOGUS_NID for Samsung PM173X
+		 * with subsystem vendor id 0x108e.
+		 */
+		return NVME_QUIRK_BOGUS_NID;
 	}
 
 	/*


### PR DESCRIPTION
For Samsung P173x with subsystem vendor id: 0x108e set NVME_QUIRK_BOGUS_NSID flag.