### PR TITLE
Fix: Duplicate SPI Handling – IPsec-v3 Compliance Concern

### DIFF
--- a/net/xfrm/xfrm_hash.h
+++ b/net/xfrm/xfrm_hash.h
@@ -116,18 +116,11 @@ static inline unsigned int __xfrm_src_hash(const xfrm_address_t *daddr,
 }
 
 static inline unsigned int
-__xfrm_spi_hash(const xfrm_address_t *daddr, __be32 spi, u8 proto,
-		unsigned short family, unsigned int hmask)
+__xfrm_spi_hash(const xfrm_address_t * __maybe_unused daddr, __be32 spi,
+		u8 __maybe_unused proto, unsigned short __maybe_unused family,
+		unsigned int hmask)
 {
-	unsigned int h = (__force u32)spi ^ proto;
-	switch (family) {
-	case AF_INET:
-		h ^= __xfrm4_addr_hash(daddr);
-		break;
-	case AF_INET6:
-		h ^= __xfrm6_addr_hash(daddr);
-		break;
-	}
+	unsigned int h = (__force u32)spi;
 	return (h ^ (h >> 10) ^ (h >> 20)) & hmask;
 }
 


### PR DESCRIPTION
XFRM_MSG_ALLOCSPI Netlink message triggers the xfrm_alloc_spi() function, which internally returns success even when the SPI value is a duplicate . This results in multiple inbound SAs having the same SPI, albeit with different destination addresses. Consequently, during SPI lookup for inbound packets, inconsistent values are returned, which leads to packet drops.

RFC 6071 states: In IPsec-v3, a unicast SA is uniquely identified by the SPI alone. Hence the change