### PR TITLE
Fix a typo in line 1296 of fs/ntfs3/super.c: recommened --> recommended

### DIFF
--- a/fs/ntfs3/super.c
+++ b/fs/ntfs3/super.c
@@ -1293,7 +1293,7 @@ static int ntfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	sbi->volume.ni = ni;
 	if (info->flags & VOLUME_FLAG_DIRTY) {
 		sbi->volume.real_dirty = true;
-		ntfs_info(sb, "It is recommened to use chkdsk.");
+		ntfs_info(sb, "It is recommended to use chkdsk.");
 	}
 
 	/* Load $MFTMirr to estimate recs_mirr. */


### PR DESCRIPTION
There was a typo in line 1296 of fs/ntfs3/super.c: "It is recommened to use chkdsk" should be "It is recommended to use chkdsk".