### PR TITLE
Update af_unix.c to increase default max_dgram_qlen.

### DIFF
--- a/net/unix/af_unix.c
+++ b/net/unix/af_unix.c
@@ -3728,7 +3728,7 @@ static int __net_init unix_net_init(struct net *net)
 {
 	int i;
 
-	net->unx.sysctl_max_dgram_qlen = 10;
+	net->unx.sysctl_max_dgram_qlen = 512;
 	if (unix_sysctl_register(net))
 		goto out;
 


### PR DESCRIPTION
Became an issue using unix sockets in a BusyBox init system. May be better to find someplace in the Kconfig to set this default length.