### PR TITLE
fuse: Clarify offset field is signed despite uint64_t type

### DIFF
--- a/include/uapi/linux/fuse.h
+++ b/include/uapi/linux/fuse.h
@@ -1127,6 +1127,10 @@ struct fuse_backing_map {
 					     struct fuse_backing_map)
 #define FUSE_DEV_IOC_BACKING_CLOSE	_IOW(FUSE_DEV_IOC_MAGIC, 2, uint32_t)
 
+/*
+ * The uint64_t offset is derived from kernel loff_t and
+ * is therefore signed.
+ */
 struct fuse_lseek_in {
 	uint64_t	fh;
 	uint64_t	offset;


### PR DESCRIPTION
Add comment noting that the uint64_t offset in fuse_lseek_in is derived from kernel loff_t and should be treated as signed for negative offsets.