### PR TITLE
ksmbd: prevent use-after-free in oplock/lease break ack error path

### DIFF
--- a/fs/smb/server/smb2pdu.c
+++ b/fs/smb/server/smb2pdu.c
@@ -8585,8 +8585,7 @@ static void smb20_oplock_break_ack(struct ksmbd_work *work)
 	rsp->VolatileFid = volatile_id;
 	rsp->PersistentFid = persistent_id;
 	ret = ksmbd_iov_pin_rsp(work, rsp, sizeof(struct smb2_oplock_break));
-	if (!ret)
-		return;
+	return;
 
 err_out:
 	opinfo->op_state = OPLOCK_STATE_NONE;
@@ -8737,8 +8736,7 @@ static void smb21_lease_break_ack(struct ksmbd_work *work)
 	rsp->LeaseState = lease_state;
 	rsp->LeaseDuration = 0;
 	ret = ksmbd_iov_pin_rsp(work, rsp, sizeof(struct smb2_lease_ack));
-	if (!ret)
-		return;
+	return;
 
 err_out:
 	wake_up_interruptible_all(&opinfo->oplock_q);


### PR DESCRIPTION
This patch adds a null check for opinfo after opinfo_put() in the
error handling path of smb20_oplock_break_ack() and smb21_lease_break_ack().

Under certain failure conditions, the opinfo structure may be freed
before reaching the err_out: label, which would cause undefined
behavior if accessed.

This patch ensures that no further access is performed on opinfo if it has already been released.

Signed-off-by: LoboQ1ng <q1ngtse24@gmail.com>&Z1naX5 <zenaxu@hdu.edu.cn>