### PR TITLE
Fix the inline brackets

### DIFF
--- a/README
+++ b/README
@@ -5,8 +5,8 @@ There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.
 
-In order to build the documentation, use ``make htmldocs`` or
-``make pdfdocs``.  The formatted documentation can also be read online at:
+In order to build the documentation, use `make htmldocs` or
+`make pdfdocs`.  The formatted documentation can also be read online at:
 
     https://www.kernel.org/doc/html/latest/
 


### PR DESCRIPTION
Currently in `README.md`, there is a mistyped inline section, supposed to be like `this` but was like ``this``. This PR fixes that formatting issue.