### PR TITLE
staging: axis-fifo: fix line over 80 characters warnings

### DIFF
--- a/drivers/staging/axis-fifo/axis-fifo.c
+++ b/drivers/staging/axis-fifo/axis-fifo.c
@@ -219,7 +219,8 @@ static ssize_t axis_fifo_read(struct file *f, char __user *buf,
 			if (ret == 0) {
 				ret = -EAGAIN;
 			} else if (ret != -ERESTARTSYS) {
-				dev_err(fifo->dt_device, "wait_event_interruptible_timeout() error in read (ret=%i)\n",
+				dev_err(fifo->dt_device,
+					"wait_event_interruptible_timeout() error in read (ret=%i)\n",
 					ret);
 			}
 
@@ -235,7 +236,8 @@ static ssize_t axis_fifo_read(struct file *f, char __user *buf,
 	}
 
 	if (bytes_available > len) {
-		dev_err(fifo->dt_device, "user read buffer too small (available bytes=%zu user buffer bytes=%zu)\n",
+		dev_err(fifo->dt_device,
+			"user read buffer too small (available bytes=%zu user buffer bytes=%zu)\n",
 			bytes_available, len);
 		ret = -EINVAL;
 		goto end_unlock;


### PR DESCRIPTION
## Description

This patch addresses coding style issues in the axis-fifo driver where several lines exceeded the 80 character limit recommended by the kernel coding style guidelines.

## Changes Made

- Reformatted long dev_err() statements to split across multiple lines
- Maintained proper indentation and alignment
- No functional changes, purely formatting improvements

## Testing

The changes have been validated with:
- checkpatch.pl shows no errors and reduced warnings
- Compilation tested successfully
- Code remains functionally identical

## Motivation

While reviewing staging drivers for potential improvements, I noticed several lines in axis-fifo.c that violated the 80-character guideline. These long lines can make the code harder to read, especially on standard terminals or when doing side-by-side code reviews.

This is my first contribution to the Linux kernel. I've carefully reviewed the documentation and followed the submission guidelines. Looking forward to your feedback.